### PR TITLE
fix subscript column names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,15 @@
+======================
+Changes for Crate JDBC
+======================
+
+Unreleased
+==========
+
+ - change column names of nested fields to subscript notation
+   in DatabaseMetaData as these names are used to query those fields
+
+ - special array type CrateArray
+
+ - initial release
+
+

--- a/src/main/java/io/crate/client/jdbc/CrateDatabaseMetaData.java
+++ b/src/main/java/io/crate/client/jdbc/CrateDatabaseMetaData.java
@@ -828,7 +828,7 @@ public class CrateDatabaseMetaData implements DatabaseMetaData {
             rows[i][0] = null;
             rows[i][1] = sqlResponse.rows()[i][0];
             rows[i][2] = sqlResponse.rows()[i][1];
-            rows[i][3] = sqlResponse.rows()[i][2];
+            rows[i][3] = StringUtils.dottedToSqlPath((String)sqlResponse.rows()[i][2]);
             rows[i][4] = sqlTypeOfCrateType((String)sqlResponse.rows()[i][3]);
             rows[i][5] = sqlResponse.rows()[i][3];
             rows[i][6] = null;

--- a/src/main/java/io/crate/client/jdbc/StringUtils.java
+++ b/src/main/java/io/crate/client/jdbc/StringUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.client.jdbc;
+
+import com.google.common.base.Splitter;
+
+import java.util.Iterator;
+
+public class StringUtils {
+    public static final Splitter PATH_SPLITTER = Splitter.on('.');
+
+    public static String dottedToSqlPath(String dottedPath) {
+        Iterable<String> splitted = PATH_SPLITTER.split(dottedPath);
+        Iterator<String> iter = splitted.iterator();
+        StringBuilder builder = new StringBuilder(iter.next());
+        while (iter.hasNext()) {
+            builder.append("['").append(iter.next()).append("']");
+        }
+        return builder.toString();
+    }
+
+}


### PR DESCRIPTION
change column names of nested fields to subscript notation in DatabaseMetaData as these names are used to query those fields
