### PR TITLE
Don't raise exception if update clause affect 0 rows

### DIFF
--- a/src/main/java/io/crate/client/jdbc/CrateStatement.java
+++ b/src/main/java/io/crate/client/jdbc/CrateStatement.java
@@ -124,7 +124,7 @@ public class CrateStatement implements Statement {
         SQLRequest sqlRequest = new SQLRequest(sql);
         sqlRequest.includeTypesOnResponse(true);
         sqlResponse = connection.client().sql(sqlRequest).actionGet();
-        if (sqlResponse.rowCount() < 0 || sqlResponse.rowCount() != sqlResponse.rows().length) {
+        if (sqlResponse.rowCount() <= 0 || sqlResponse.rowCount() != sqlResponse.rows().length) {
             return false;
         }
         resultSet = new CrateResultSet(this, sqlResponse);

--- a/src/test/java/io/crate/client/jdbc/CrateJDBCIntegrationTest.java
+++ b/src/test/java/io/crate/client/jdbc/CrateJDBCIntegrationTest.java
@@ -167,4 +167,11 @@ public class CrateJDBCIntegrationTest extends AbstractIntegrationTest {
         assertThat(counter, is(13));
 
     }
+
+    @Test
+    public void testExecuteUpdateWhenNothingMatches() throws Exception {
+        Statement statement = connection.createStatement();
+        assertThat(statement.executeUpdate("update test set string_field = 'new_value' where string_field = 'nothing_matches_this'"), is(0));
+    }
+
 }


### PR DESCRIPTION
I was getting the Java::JavaSql::SQLException: Execution of statement returned a ResultSet for queries that didn't match any rows.
