### PR TITLE
Don't raise exception if update clause affect 0 rows. 

### DIFF
--- a/src/main/java/io/crate/client/jdbc/CrateStatement.java
+++ b/src/main/java/io/crate/client/jdbc/CrateStatement.java
@@ -43,7 +43,7 @@ public class CrateStatement extends CrateStatementBase {
     @Override
     public int executeUpdate(String sql) throws SQLException {
         checkClosed();
-        if (execute(sql)) {
+        if (execute(sql) && sqlResponse.rowCount() > 0) {
             resultSet = null;
             throw new SQLException("Execution of statement returned a ResultSet");
         } else {

--- a/src/test/java/io/crate/client/jdbc/CrateJDBCIntegrationTest.java
+++ b/src/test/java/io/crate/client/jdbc/CrateJDBCIntegrationTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class CrateJDBCIntegrationTest extends AbstractIntegrationTest {
@@ -338,5 +339,17 @@ public class CrateJDBCIntegrationTest extends AbstractIntegrationTest {
             // test that we can get the types, whatever they are
             assertThat(metaData.getColumnType(i), instanceOf(Integer.class));
         }
+    }
+
+    @Test
+    public void testSelectWhenNothingMatches() throws Exception {
+        Statement statement = connection.createStatement();
+        assertTrue(statement.execute("select * from test where string_field = 'nothing_matches_this'"));
+    }
+
+    @Test
+    public void testExecuteUpdateWhenNothingMatches() throws Exception {
+        Statement statement = connection.createStatement();
+        assertThat(statement.executeUpdate("update test set string_field = 'new_value' where string_field = 'nothing_matches_this'"), is(0));
     }
 }


### PR DESCRIPTION
There is also test to make sure select queries returning empty set are not affected by this because i changed the wrong thing first and that started failing.

Now tests pass and it works like I expect.
