### PR TITLE
delete target folder in extractTopfolder task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ def download (String url, String name){
 }
 
 def extractTopfolder(File src, String trg){
+    // delete target folder. Otherwise old files will stick around and lead to strange errors
+    new File(trg).delete()
+
     copy {
         includeEmptyDirs = false
         FileTree ft
@@ -325,5 +328,5 @@ idea {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.1'
+    gradleVersion = '2.2.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip


### PR DESCRIPTION
having a old crate version + new crate version in the same folder might lead
to strange results.

also updates gradle to 2.2.1
