### PR TITLE
Update year in copyright license: Trello #693

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Crate Data JDBC Driver
-Copyright 2013-2014 CRATE Technology GmbH ("Crate")
+Copyright 2013-2015 CRATE Technology GmbH ("Crate")
 
 
 Licensed to CRATE Technology GmbH (referred to in this notice as "Crate")


### PR DESCRIPTION
The year in the license file needed to be updated from 2014 to 2015