### PR TITLE
Fixes #69 CratePreparedStatement.execute() returns null

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Changes for Crate Data JDBC Client
  - Do not throw exception when ``createStatement`` and ``prepareStatement`` are
    invoked with supported result set type, concurrency and holdability
 
+ - Fix: do not return ``null`` but an empty ``ResultSet`` if there are no
+   matches for a ``PreparedStatement``
+
 2015/04/09 1.6.0
 ================
 

--- a/src/main/java/io/crate/client/jdbc/CratePreparedStatement.java
+++ b/src/main/java/io/crate/client/jdbc/CratePreparedStatement.java
@@ -146,7 +146,7 @@ public class CratePreparedStatement extends CrateStatementBase implements Prepar
     @Override
     public int getUpdateCount() throws SQLException {
         checkClosed();
-        if (resultSet == null && sqlResponse != null) {
+        if (resultSet.isBeforeFirst() && sqlResponse != null) {
             return (int) sqlResponse.rowCount();
         }
         return -1;
@@ -159,10 +159,10 @@ public class CratePreparedStatement extends CrateStatementBase implements Prepar
 
         sqlRequest.args(currentParams);
         executeSingle();
+        resultSet = new CrateResultSet(this, sqlResponse);
         if (!hasResultSet(sqlResponse)) {
             return false;
         }
-        resultSet = new CrateResultSet(this, sqlResponse);
         return true;
     }
 

--- a/src/main/java/io/crate/client/jdbc/CrateResultSet.java
+++ b/src/main/java/io/crate/client/jdbc/CrateResultSet.java
@@ -379,7 +379,7 @@ public class CrateResultSet implements ResultSet {
     @Override
     public boolean isBeforeFirst() throws SQLException {
         checkClosed();
-        return rowIdx == -1;
+        return rowIdx == -1 && sqlResponse.rowCount() > 0;
     }
 
     @Override

--- a/src/test/java/io/crate/client/jdbc/AbstractCrateJDBCTest.java
+++ b/src/test/java/io/crate/client/jdbc/AbstractCrateJDBCTest.java
@@ -104,7 +104,7 @@ public abstract class AbstractCrateJDBCTest {
         } else if (o instanceof SQLRequest) {
             response = getResponse((SQLRequest) o);
         } else {
-            throw new IllegalArgumentException("invalid SQL requuest");
+            throw new IllegalArgumentException("invalid SQL request");
         }
 
         return new PlainActionFuture<SQLResponse>() {

--- a/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
+++ b/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
@@ -37,6 +37,8 @@ import static io.crate.shade.com.google.common.collect.Maps.newHashMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.*;
 
 /**
@@ -189,6 +191,17 @@ public class CrateJDBCIntegrationTest {
         Assert.assertThat(objArray.getBaseType(), is(Types.JAVA_OBJECT));
         Object firstObject = ((Object[])objArray.getArray())[0];
         Assert.assertThat(firstObject, instanceOf(Map.class));
+    }
+
+    @Test
+    public void testSelectWithoutResultUsingPreparedStatement() throws Exception {
+        PreparedStatement preparedStatement = connection.prepareStatement("select * from test where id = ?");
+        preparedStatement.setInt(1,2);
+
+        ResultSet resultSet = preparedStatement.executeQuery();
+
+        assertThat(resultSet, notNullValue());
+        assertThat(resultSet.isBeforeFirst(), is(false));
     }
 
     @Test


### PR DESCRIPTION
Due to unforeseen circumstances (summer finally arriving) it took me a little longer than expected, but this PR fixes the problem that `CratePreparedStatement.execute()` was returning null (which is explicitly forbidden by the `PreparedStatement`interface) instead of an empty `ResultSet`. 