### PR TITLE
crate/crate-jdbc#82 Close the crate client (and its connections) when the connection object gets a close() request

### DIFF
--- a/src/main/java/io/crate/client/jdbc/CrateConnection.java
+++ b/src/main/java/io/crate/client/jdbc/CrateConnection.java
@@ -111,6 +111,7 @@ public class CrateConnection implements Connection {
 
     @Override
     public void close() throws SQLException {
+        crateClient.close();
         crateClient = null;
     }
 


### PR DESCRIPTION
https://github.com/crate/crate-jdbc/issues/82