### PR TITLE
close Crate client to shut down remaining thread pools and

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,8 +2,11 @@
 Changes for Crate Data JDBC Client
 ==================================
 
- Unreleased
- ==========
+Unreleased
+==========
+
+ - Fix: close Crate client to shut down remaining thread pools and connections
+   when closing JDBC connection
 
 2015/09/01 1.9.0
 ================

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ sourceSets {
 
 ext {
     downloadDir = new File(rootDir, 'downloads')
-    crate_version = '0.49.5'
+    crate_version = '0.51.6'
 }
 
 

--- a/src/main/java/io/crate/client/jdbc/CrateConnection.java
+++ b/src/main/java/io/crate/client/jdbc/CrateConnection.java
@@ -111,6 +111,9 @@ public class CrateConnection implements Connection {
 
     @Override
     public void close() throws SQLException {
+        if (crateClient != null) {
+            crateClient.close();
+        }
         crateClient = null;
     }
 


### PR DESCRIPTION
connections when closing JDBC connection