### PR TITLE
close JDBC connection correctly before raising exception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Fix: close JDBC connection correctly before raising exception for invalid
+   URL format in order to prevent memory leak
+
  - Fix: URL parameters after the schema name are ignored
 
  - Fix: close Crate client to shut down remaining thread pools and connections

--- a/src/main/java/io/crate/client/jdbc/CrateDriver.java
+++ b/src/main/java/io/crate/client/jdbc/CrateDriver.java
@@ -70,6 +70,7 @@ public class CrateDriver implements Driver {
                 String[] pathAndParams = urlParts[1].split("\\?");
                 connection.setSchema(pathAndParams[0]);
             } else if (urlParts.length > 2) {
+                connection.close();
                 throw new SQLException("URL format is invalid. " +
                         "Valid format is: [jdbc:]crate://[host1:port1][, host2:port2 ...]/[schema][?param=value]");
             }


### PR DESCRIPTION
for invalid URL format in order to prevent memory leak