### PR TITLE
Fix getTransactionIsolation to adhere JDBC spec

### DIFF
--- a/src/main/java/io/crate/client/jdbc/CrateConnection.java
+++ b/src/main/java/io/crate/client/jdbc/CrateConnection.java
@@ -165,7 +165,7 @@ public class CrateConnection implements Connection {
     @Override
     public int getTransactionIsolation() throws SQLException {
         checkClosed();
-        throw new SQLFeatureNotSupportedException("Connection: getTransactionIsolation not supported");
+        return Connection.TRANSACTION_NONE;
     }
 
     @Override


### PR DESCRIPTION
Provides the fix for https://github.com/crate/crate-jdbc/issues/88