### PR TITLE
implement ability to set properties in conn-string

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - It is now possible to set connection properties via the connection string.
+
 2016/06/27 1.12.3
 =================
 

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -88,6 +88,7 @@ With JDBC, a database is represented by a URL (Uniform Resource Locator).
 With Crate, this takes the following form::
 
     [jdbc:]crate://<host>:<transport-port>[,<host>:<transport-port> , ...][/<schemaName>]
+        [?propertyName1=propertyValue1[&propertyName2=propertyValue2]...]
 
 The ``jdbc:`` prefix is optional. For example. To connect to a single server
 the following two formats are both allowed::
@@ -133,6 +134,10 @@ Properties can be specified when connecting to Crate using the JDBC driver::
     Properties properties = new Properties();
     properties.put(<key>, <value>);
     Connection conn = DriverManager.getConnection("crate://localhost:4300", properties);
+
+In addition connection properties can be passed via the JDBC URL::
+
+    Connection conn = DriverManager.getConnection("crate://localhost:4300?property1=value1&property2=value2");
 
 Crate JDBC driver supports following properties:
 

--- a/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCDriverTest.java
+++ b/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCDriverTest.java
@@ -192,4 +192,14 @@ public class CrateJDBCDriverTest extends CrateJDBCIntegrationTest {
         executor.shutdown();
         assertThat(crateDriver.clientURLs().size(), is(0));
     }
+
+    @Test
+    public void testClientPropertyUrlParser() throws Exception {
+        Connection conn = DriverManager.getConnection("crate://" + hostAndPort + "?prop1=value1&prop2=value2");
+        Properties properties = conn.getClientInfo();
+        assertThat(properties.size(), is(3));
+        assertThat(properties.getProperty("prop1"), is("value1"));
+        assertThat(properties.getProperty("prop2"), is("value2"));
+        conn.close();
+    }
 }


### PR DESCRIPTION
JDBC client properties can be set via connection string
e.g. `crate://localhost:4300?property1=value1&...`