### PR TITLE
added property to supoort subcolumns in metadata

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Added JDBC property that allows to fetch nested columns if table metadata is queried.
+
  - It is now possible to set connection properties via the connection string.
 
 2016/06/27 1.12.3

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -151,6 +151,12 @@ Crate JDBC driver supports following properties:
          which will make the Crate JDBC driver compatible with most 3rd party
          applications that usually require transactional databases.
 
+:showsubcolumns:  (Default: ``false``) If this property value is set to ``true``
+                  it will fetch nested column information out of the table
+                  metadata. The output is equivalent to the result if
+                  ``information_schema.columns`` gets queried.
+                  By setting the property to ``false`` only the root column
+                  (the object field name) itself is returned.
 
 Compatibility
 =============

--- a/src/main/java/io/crate/client/jdbc/CrateDatabaseMetaData.java
+++ b/src/main/java/io/crate/client/jdbc/CrateDatabaseMetaData.java
@@ -809,10 +809,13 @@ public class CrateDatabaseMetaData implements DatabaseMetaData {
         String stmt = "select schema_name, table_name, column_name, data_type, ordinal_position " +
                 "from information_schema.columns";
         List<String> whereConditions = new ArrayList<String>();
+        boolean showSubcolumns = Boolean.valueOf(connection.getClientInfo().getProperty("showsubcolumns", "false"));
 
-        // exclude nested columns
-        whereConditions.add("column_name not like '%[%]'");
-        whereConditions.add("column_name not like '%.%'"); // backward compatibility pre 0.40.X
+        if (!showSubcolumns) {
+            // exclude nested columns
+            whereConditions.add("column_name not like '%[%]'");
+            whereConditions.add("column_name not like '%.%'"); // backward compatibility pre 0.40.X
+        }
 
         if (schemaPattern != null && schemaPattern.equals("")) {
             whereConditions.add("schema_name is null");

--- a/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCConnectionTest.java
+++ b/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCConnectionTest.java
@@ -48,6 +48,7 @@ public class CrateJDBCConnectionTest extends CrateJDBCIntegrationTest {
 
     private static Connection connection;
     private static String hostAndPort;
+    private static String connectionString;
     private static CrateClient client;
 
     @BeforeClass
@@ -58,7 +59,8 @@ public class CrateJDBCConnectionTest extends CrateJDBCIntegrationTest {
                 server.crateHost(),
                 server.transportPort()
         );
-        connection = DriverManager.getConnection("crate://" + hostAndPort);
+        connectionString = "crate://" + hostAndPort;
+        connection = DriverManager.getConnection(connectionString);
         client = new CrateClient(hostAndPort);
         setUpTables();
     }
@@ -333,6 +335,20 @@ public class CrateJDBCConnectionTest extends CrateJDBCIntegrationTest {
         }
         assertThat(counter, is(15));
 
+    }
+
+    @Test
+    public void testIncludeNestedColumns() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("showsubcolumns", "true");
+        Connection connection = DriverManager.getConnection(connectionString, properties);
+        ResultSet resultSet = connection.getMetaData().getColumns(null, "sys", "nodes", null);
+        int counter = 0;
+        while (resultSet.next()) {
+            counter++;
+        }
+        assertThat(counter, is(99));
+        connection.close();
     }
 
     /**


### PR DESCRIPTION
This support that nested columns/subcolumns are returned if metadata is
fetched.

`showsubcolumns=false` (default): exclude nested columns of metadata.
`showsubcolumns=true`: includes nested columns in the metadata list.