### PR TITLE
fixed jdbc exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.crate:crate-client:0.55.2'
+    compile 'io.crate:crate-client:0.55.4'
     testCompile "io.crate:crate-testing:0.4.0"
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.11'


### PR DESCRIPTION
bug fixed!
when use crate-jdbc-1.13.0 to connect to 0.55.4 crate cluster,that will throw an exception:

> Caused by: java.lang.IllegalArgumentException: An SPI class of type io.crate.shade.org.apache.lucene.codecs.PostingsFormat with name 'Lucene50' does not exist. You need to add the corresponding JAR file supporting this SPI to your classpath. The current classpath supports the following names: []
>  at io.crate.shade.org.apache.lucene.util.NamedSPILoader.lookup(NamedSPILoader.java:114)
>  at io.crate.shade.org.apache.lucene.codecs.PostingsFormat.forName(PostingsFormat.java:112)
>  at io.crate.shade.org.elasticsearch.common.lucene.Lucene.(Lucene.java:65)
> CONSOLE# ... 29 more

to fix this exception, upgrade crate client to 0.55.4
