### PR TITLE
fix the packaging of the crate standalone jdbc driver

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Fix: Pacakaging of the Crate standalone JDBC driver for the versions
+   which use crate-client <= 0.55.2.
+
 2016/07/11 1.13.0
 =================
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,7 @@ jar {
 task jarStandalone(type: Jar, dependsOn: getVersion) {
     baseName 'crate-jdbc-standalone'
     from configurations.compile.collect {
-        it.isDirectory() ? it : zipTree(it).matching{
-            exclude 'META-INF/**'
-        }
+        it.isDirectory() ? it : zipTree(it)
     }
     from sourceSets.main.output
     doLast {


### PR DESCRIPTION
The Crate standalone JDBC driver which uses the `crate-client`
<= `0.55.2` was not compatible with `crate` >= `0.55.3`. The problem
was caused by missing META-INF/services, e.g. https://github.com/crate/crate-jdbc/pull/131
Lucene uses SPI (Service provider interface) that requires the correct
configuration of META-INF/services which was excluded in the previous
builds.