### PR TITLE
use SPI for loading the Crate JDBC driver

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Applications no longer need to load the Crate JDBC driver explicitly
+   using `Class.forName()`.
+
 2016/09/07 1.13.1
 =================
 

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -74,11 +74,9 @@ Alternatively you can follow the instructions on the Bintray repository overview
 JDBC Driver Class
 =================
 
-The Crate JDBC driver class is ``io.crate.client.jdbc.CrateDriver``.
+A connection can be established using ``DriverManager.getConnection()``
+method, e.g.::
 
-A connection is obtained from the DriverManager, e.g.::
-
-    Class.forName("io.crate.client.jdbc.CrateDriver");
     Connection conn = DriverManager.getConnection("crate://localhost:4300");
 
 JDBC URL Format

--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+io.crate.client.jdbc.CrateDriver

--- a/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCByPassSpecSettingTest.java
+++ b/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCByPassSpecSettingTest.java
@@ -41,7 +41,6 @@ public class CrateJDBCByPassSpecSettingTest extends CrateJDBCIntegrationTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        Class.forName("io.crate.client.jdbc.CrateDriver");
         CrateTestServer server = testCluster.randomServer();
         connectionString = String.format(Locale.ENGLISH, "crate://%s:%d", server.crateHost(), server.transportPort());
         strictProperties.put("strict", "true");

--- a/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCConnectionTest.java
+++ b/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCConnectionTest.java
@@ -53,7 +53,6 @@ public class CrateJDBCConnectionTest extends CrateJDBCIntegrationTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        Class.forName("io.crate.client.jdbc.CrateDriver");
         CrateTestServer server = testCluster.randomServer();
         hostAndPort = String.format(Locale.ENGLISH, "%s:%d",
                 server.crateHost(),
@@ -76,7 +75,6 @@ public class CrateJDBCConnectionTest extends CrateJDBCIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        Class.forName("io.crate.client.jdbc.CrateDriver");
         insertIntoTable();
     }
 

--- a/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCDriverTest.java
+++ b/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCDriverTest.java
@@ -64,7 +64,6 @@ public class CrateJDBCDriverTest extends CrateJDBCIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        Class.forName("io.crate.client.jdbc.CrateDriver");
         driver = new CrateDriver();
     }
 

--- a/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
+++ b/src/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
@@ -47,10 +47,4 @@ public class CrateJDBCIntegrationTest extends RandomizedTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void setUp() throws Exception {
-        Class.forName("io.crate.client.jdbc.CrateDriver");
-    }
-
 }


### PR DESCRIPTION
`Class.forName("io.crate.client.jdbc.CrateDriver")` is no longer required.