### PR TITLE
autocommit and fetch size

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Allow setting autocommit to false in non-strict mode.
+   Autocommit must be false otherwise ``setFetchSize()`` on the statement does
+   not have any effect and all rows are fetched at once.
+
 2017/01/20 2.1.4
 ================
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 dependencies {
     compile project(':pg')
-    testCompile 'io.crate:crate-testing:0.4.3'
+    testCompile 'io.crate:crate-testing:0.5.0'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
     testCompile ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.1.11') {

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCByPassSpecSettingTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCByPassSpecSettingTest.java
@@ -46,7 +46,7 @@ public class CrateJDBCByPassSpecSettingTest extends CrateJDBCIntegrationTest {
         Connection connection = DriverManager.getConnection(connectionString);
 
         connection.setAutoCommit(false);
-        assertThat(connection.getAutoCommit(), is(true));
+        assertThat(connection.getAutoCommit(), is(false));
 
         connection.setAutoCommit(true);
         assertThat(connection.getAutoCommit(), is(true));
@@ -89,7 +89,7 @@ public class CrateJDBCByPassSpecSettingTest extends CrateJDBCIntegrationTest {
     public void testSetAutoCommitToFalseStrictTrue() throws SQLException {
         try(Connection connection = DriverManager.getConnection(connectionString, strictProperties)) {
             expectedException.expect(SQLFeatureNotSupportedException.class);
-            expectedException.expectMessage("The auto-commit mode cannot be disabled. The Crate JDBC driver does not support manual commit.");
+            expectedException.expectMessage("The auto-commit mode cannot be disabled in strict mode. The Crate JDBC driver does not support manual commit.");
             connection.setAutoCommit(false);
         }
     }

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCFetchSizeIntegrationTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCFetchSizeIntegrationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.client.jdbc.integrationtests;
+
+import org.junit.Test;
+import org.postgresql.core.*;
+
+import java.lang.reflect.Field;
+import java.sql.*;
+import java.util.List;
+
+
+/**
+ * We are allowed to disable autoCommit (= manual commit) if strict mode is not enabled.
+ * Manual commit is required for {@link org.postgresql.jdbc.PgStatement#setFetchSize(int)} to work correctly!
+ * If autoCommit is true {@link org.postgresql.jdbc.PgStatement#executeInternal(CachedQuery, ParameterList, int)}
+ * will never set the QueryExecutor.QUERY_FORWARD_CURSOR flag and therefore fetch all results at once instead of
+ * batching them.
+ */
+public class CrateJDBCFetchSizeIntegrationTest extends CrateJDBCIntegrationTest {
+
+    /**
+     * fetch size and execution flag is correctly appied if autoCommit == false
+     */
+    @Test
+    public void testFetchSizeNotIgnoredIfManualCommit() throws Exception {
+        try (Connection connection = DriverManager.getConnection(getConnectionString())) {
+            connection.setAutoCommit(false);
+            try (Statement statement = connection.createStatement()) {
+                statement.setFetchSize(10);
+                statement.execute("select * from sys.summits");
+                ResultSet rs = statement.getResultSet();
+                assertEquals(10, rs.getFetchSize());
+                Field rowsField = rs.getClass().getDeclaredField("rows");
+                rowsField.setAccessible(true);
+                List rows = (List) rowsField.get(rs);
+                assertEquals(10, rows.size());
+            }
+        }
+    }
+
+    /*
+     * fetch size is ignored if autoCommit == true
+     */
+    @Test
+    public void testFetchSizeIgnoredIfAutocommit() throws Exception {
+        try (Connection connection = DriverManager.getConnection(getConnectionString())) {
+            connection.setAutoCommit(true);
+            try (Statement statement = connection.createStatement()) {
+                statement.setFetchSize(10);
+                statement.execute("select * from sys.summits");
+                ResultSet rs = statement.getResultSet();
+                assertEquals(10, rs.getFetchSize());
+                Field rowsField = rs.getClass().getDeclaredField("rows");
+                rowsField.setAccessible(true);
+                List rows = (List) rowsField.get(rs);
+                assertEquals(1605, rows.size());
+            }
+        }
+    }
+}


### PR DESCRIPTION
The statement fetch size (set via `setFetchSize()`) is ignored on execution if autocommit (set via `setAutoCommit()`) is true (which is default).

These changes will allow to set autocommit to false (only in non-strict mode) which previously lead to an exception.

upstream pr: https://github.com/crate/pgjdbc/pull/27
