### PR TITLE
Fix: DataBaseMetadata returned wrong empty result

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Fix: Unsupported DatabaseMetaData methods returned a row with all values set
+   to ``null`` instead of an empty result with no rows at all.
+
  - Changed the assumeMinServerVersion default to "9.5", because CrateDB
    emulates Postgres version 9.5.
    This change eliminates initial SET SESSION statements which are ignored

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCMetaDataIntegrationTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCMetaDataIntegrationTest.java
@@ -220,4 +220,14 @@ public class CrateJDBCMetaDataIntegrationTest extends CrateJDBCIntegrationTest {
         assertThat(rs.getString("COLUMN_NAME"), is("id2"));
         connection.createStatement().execute("drop table t_multi_pks");
     }
+
+    @Test
+    public void testUnsupportedMethodWithEmptyImpl() throws SQLException {
+        DatabaseMetaData metaData = connection.getMetaData();
+        ResultSet rs = metaData.getPseudoColumns("", "doc", "information_schema", "pg_catalog");
+        assertThat(rs.getMetaData().getColumnCount(), is(12));
+        assertThat(rs.getMetaData().getColumnName(1), is("TABLE_CAT"));
+        // The empty result doesn't contain any rows
+        assertThat(rs.next(), is(false));
+    }
 }


### PR DESCRIPTION
See also: https://github.com/crate/pgjdbc/pull/29