### PR TITLE
Bump Sphinx version used to 1.6.3.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 crate-docs-theme
+Sphinx>=1.6.3

--- a/docs/versions.cfg
+++ b/docs/versions.cfg
@@ -2,7 +2,7 @@
 Jinja2 = 2.7.2
 MarkupSafe = 0.23
 Pygments = 1.6
-Sphinx = 1.2.2
+Sphinx = 1.6.3
 docutils = 0.11
 zc.buildout = 2.2.5
 zc.recipe.egg = 2.0.1


### PR DESCRIPTION
This fixes an issue in Sphinx that caused builds on RTD to fail
if the contents tree was empty, as is the case in the JDBC docs
(since they're a single page). This was fixed in version 1.6.3,
which now only traverses a TOC tree if it is not null.

Issue: https://github.com/sphinx-doc/sphinx/pull/3518

@nslater @chaudum You might want to rebase this change into your fix-docs branch and see if this solves your build problem (you'll have to wipe the branch's build environment on RTD first, I think).