### PR TITLE
Travis: Run on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-dist: precise
+dist: trusty
 language: java
 jdk:
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 env:
   - CRATE_VERSION=0.56.4
@@ -13,14 +12,16 @@ matrix:
   exclude:
     - jdk: openjdk7
       env: CRATE_VERSION=1.0.1
-    - jdk: oraclejdk7
-      env: CRATE_VERSION=1.0.1
 
 cache:
   directories:
     - $HOME/.m2
 
 sudo: false
+
+# Workaround for https://github.com/gradle/gradle/issues/2421
+install:
+  - JAVA_HOME=$(jdk_switcher home openjdk8) ./gradlew classes testClasses
 
 script: ./gradlew test -s
 

--- a/build.gradle
+++ b/build.gradle
@@ -345,5 +345,5 @@ idea {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.0'
+    gradleVersion = '4.0.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.2-bin.zip


### PR DESCRIPTION
Removes oraclejdk7 from the build matrix because of
travis-ci/travis-ci#7884