### PR TITLE
enabled sitemap generation through sphinx module in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
 from crate.theme.rtd.conf.crate_jdbc import *
 
 exclude_patterns = ['eggs/**', 'requirements.txt']
+site_url = 'https://crate.io/docs/clients/jdbc/en/latest/'
+extensions = ['sphinx_sitemap']


### PR DESCRIPTION
* added extension to `docs/conf.py`
* set base url in `docs/conf.py`
* this will automatically generate a sitemap for every docs build