### PR TITLE
Fixed documentation regarding randomization of hosts.

### DIFF
--- a/docs/connecting.txt
+++ b/docs/connecting.txt
@@ -68,18 +68,10 @@ separated list until the first successfull connection is established.
     default, and then moving on to the next node if that node is not available,
     and so on. In aggregate, this should spread load fairly evenly.
 
-    Here's one way shuffle the list of hosts in Java:
+    To achieve that just set the parameter ``loadBalanceHosts`` to ``true``.
+    E.g.::
 
-    .. code-block:: java
-
-        List<String> hosts = new ArrayList<>(3);
-        hosts.add("host1.example.com:5432");
-        hosts.add("host2.example.com:5432");
-        hosts.add("host3.example.com:5432");
-
-        Collections.shuffle(hosts);
-        String url = "jdbc:crate://" + String.join(",", hosts) + "/";
-        Connection conn = DriverManager.getConnection(url);
+        crate://host1.example.com:5432,host2.example.com:5432/?loadBalanceHosts=true
 
 To specify a schema, the ``setSchema`` method must be explicitly called on
 the connection. If no schema is provided, the ``doc`` default schema will be


### PR DESCRIPTION
There is no need to do some shuffling in application code as
there is already a JDBC param: loadBalanceHosts=true