### PR TITLE
updated getPrimaryKeys() method in MetaData for CrateDB >= 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - CRATE_VERSION=0.57.6
   - CRATE_VERSION=1.0.1
   - CRATE_VERSION=2.2.0
+  - CRATE_VERSION=2.3.4
 
 matrix:
   exclude:
@@ -15,6 +16,8 @@ matrix:
       env: CRATE_VERSION=1.0.1
     - jdk: openjdk7
       env: CRATE_VERSION=2.2.0
+    - jdk: openjdk7
+      env: CRATE_VERSION=2.3.4
 
 cache:
   directories:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Updated ``getPrimaryKeys()`` method in DatabaseMetaData to work correctly
+   with CrateDB 2.3.0 and newer.
+
 2017/08/18 2.2.0
 ================
 

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
@@ -40,12 +40,21 @@ import java.util.Random;
 @ThreadLeakScope(ThreadLeakScope.Scope.SUITE)
 public class CrateJDBCIntegrationTest extends RandomizedTest {
 
-    private static String[] CRATE_VERSIONS = new String[]{"0.56.4", "0.57.6", "1.0.1", "2.2.0"};
+    private static String[] CRATE_VERSIONS = new String[]{
+            "0.56.4",
+            "0.57.6",
+            "1.0.1",
+            "1.1.6",
+            "2.0.7",
+            "2.1.9",
+            "2.2.7",
+            "2.3.4"
+    };
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    public static CrateTestCluster testCluster;
+    static CrateTestCluster testCluster;
 
     private static String getRandomServerVersion() {
         String version = System.getenv().get("CRATE_VERSION");


### PR DESCRIPTION
Requires upstream change: https://github.com/crate/pgjdbc/pull/32
Fixes #255 