### PR TITLE
testing: support running tests against CrateDB from URL

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -21,6 +21,16 @@ Run the unit tests like so::
 
     $ ./gradlew test
 
+Integration tests use a randomized CrateDB version. If you want to run the
+tests against a specific version you can either use the ``CRATE_VERSION`` or
+``CRATE_URL`` environment variable, e.g.::
+
+    $ CRATE_VERSION=2.3.4 ./gradlew test
+
+or::
+
+    $ CRATE_URL=https://cdn.crate.io/downloads/releases/nightly/crate-0.58.0-201611210301-7d469f8.tar.gz ./gradlew test
+
 Preparing a Release
 ===================
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 dependencies {
     compile project(':pg')
-    testCompile 'io.crate:crate-testing:0.6.0'
+    testCompile 'io.crate:crate-testing:0.6.1'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
     testCompile ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.1.11') {

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/CrateJDBCIntegrationTest.java
@@ -67,10 +67,14 @@ public class CrateJDBCIntegrationTest extends RandomizedTest {
 
     @BeforeClass
     public static void setUpCluster() throws Throwable {
-        testCluster = CrateTestCluster
-                .fromVersion(getRandomServerVersion())
-                .keepWorkingDir(false)
-                .build();
+        String downloadUrl = System.getenv().get("CRATE_URL");
+        CrateTestCluster.Builder builder;
+        if (downloadUrl != null) {
+            builder = CrateTestCluster.fromURL(downloadUrl);
+        } else {
+            builder = CrateTestCluster.fromVersion(getRandomServerVersion());
+        }
+        testCluster = builder.keepWorkingDir(false).build();
         testCluster.before();
     }
 


### PR DESCRIPTION
The URL can be specified via the CRATE_URL environment variable:

```
CRATE_URL=https://cdn.crate.io/downloads/releases/nightly/crate-3.0.0-201803120203-6a4e651.tar.gz ./gradlew test
```