### PR TITLE
do not register the shaded Postgres driver class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+ - Register driver class correctly so it does not require explicit
+   initialization. This fixes problems with some third-party connection pooling
+   tools.
+
  - Updated ``getTables()`` method in DatabaseMetaData to only return tables but
    not views with CrateBD versions greater than ``2.3.x``.
 


### PR DESCRIPTION
as it causes problems with the static initialization of our CrateDriver when
used in conjunction with 3rd party connection pooling tools that do not
initialize drivers explicitly but only take the ones that are registered
with the DriverManager

see also https://github.com/crate/pgjdbc/pull/33