### PR TITLE
Added compatiblity for `isc` column type changes on CrateDB >= 4.0.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+- Added compatiblity for column type changes of
+  ``information_schema.columns.is_generated`` on CrateDB >= 4.0.0
+
 2018/12/06 2.5.1
 ================
 


### PR DESCRIPTION
The type of the `information_schema.columns.is_generated` column has
been changed from Boolean to String for SQL standard compatibility.