### PR TITLE
Upgrade crate-testing to v0.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 dependencies {
     compile project(':pg')
-    testCompile 'io.crate:crate-testing:0.6.2'
+    testCompile 'io.crate:crate-testing:0.7.0'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
     testCompile ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.1') {


### PR DESCRIPTION
crate-testing v0.7.0 adds support for using the integration test
framework against CrateDB >= 4.x (and thus the current nightly builds).
