### PR TITLE
Deleted doubled "driver"

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -4,7 +4,7 @@
 CrateDB JDBC Driver
 ===================
 
-A `type 4 JDBC driver`_ driver for `CrateDB`_.
+A `type 4 JDBC driver`_ for `CrateDB`_.
 
 `JDBC`_  is a standard Java API that provides a common interfaces for accessing
 databases in Java.


### PR DESCRIPTION
"Driver" was written two times in the beginning.

## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
