### PR TITLE
Update crate-testing to 0.9.0 to fix nightly test failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 dependencies {
     compile project(':pg')
-    testCompile 'io.crate:crate-testing:0.7.0'
+    testCompile 'io.crate:crate-testing:0.9.0'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
     testCompile ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.1') {


### PR DESCRIPTION
0.9.0 contains a fix required to run CrateDB from tarballs which have
the JDK bundled.