### PR TITLE
Update crate-testing to 0.9.1 to fix CrateDB >=4.2 test failures on MacOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 dependencies {
     compile project(':pg')
-    testCompile 'io.crate:crate-testing:0.9.0'
+    testCompile 'io.crate:crate-testing:0.9.1'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
     testCompile ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.1') {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

0.9.1 contains a fix required to run CrateDB from tarballs on MacOS which have the JDK bundled.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
