### PR TITLE
Migrate crate-jdbc to Maven Central

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+- Migrated from Bintray to Maven Central. All new releases to go to Maven Central
+  from now on.
+
 2019/07/02 2.6.0
 ================
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,23 @@
+
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
+        // Note that this is still required, until the various dependencies we use migrate over to maven central.
+        // jcenter is going to be available until February 2022.
+        jcenter()
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0'
     }
 }
 
+import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 group = "io.crate"
+
+apply plugin: 'io.codearte.nexus-staging'
 
 allprojects {
     apply plugin: 'idea'
@@ -135,6 +142,7 @@ task myJavadocs(type: Javadoc, dependsOn: processResources) {
 }
 
 task javadocJar (type: Jar, dependsOn: [getVersion, myJavadocs]) {
+    baseName 'crate-jdbc'
     classifier = 'javadoc'
     from myJavadocs.destinationDir
     doLast {
@@ -157,6 +165,7 @@ task javadocJarStandalone (type: Jar, dependsOn: [getVersion, myJavadocs]) {
 
 
 task sourceJar (type : Jar, dependsOn: [getVersion]) {
+    baseName 'crate-jdbc'
     classifier = 'sources'
     from sourceSets.main.allSource
     doLast {
@@ -208,8 +217,8 @@ install {
     }
 }
 
-project.ext.bintrayUsername = project.hasProperty('bintrayUsername') ? bintrayUsername : ""
-project.ext.bintrayPassword = project.hasProperty('bintrayPassword') ? bintrayPassword : ""
+project.ext.sonatypeUsername = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
+project.ext.sonatypeUsername = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
 project.ext.url = 'https://crate.io'
 project.ext.scm = {
     url 'https://github.com/crate/crate-jdbc'
@@ -233,12 +242,23 @@ project.ext.developers = {
 
 uploadArchives.dependsOn([signJars])
 uploadArchives {
-    repositories{
+    repositories {
         mavenDeployer {
             beforeDeployment {
                 MavenDeployment deployment -> signing.signPom(deployment)
-                if (project.ext.bintrayUsername.length() == 0 || project.ext.bintrayPassword.length() == 0) {
-                    throw new StopExecutionException("uploadArchives cannot be called without bintray username and password")
+                if (project.ext.sonatypeUsername.length() == 0 || project.ext.sonatypePassword.length() == 0) {
+                    throw new StopExecutionException("uploadArchives cannot be called without maven username and password")
+                }
+                // This is a (very) un-pretty way of attaching the asc files as artifacts to the deployment.
+                // The mavenDeployer is pretty old, not documented very well - and does not pick up .asc files.
+                // Here we're slightly abusing the system and creating "fake" .asc artifacts for each .jar file,
+                // because we know for certain that if we got there, the asc files must exist.
+                // If we don't do this, Sonatype will not allow promotion to maven central.
+                artifacts.each { ca ->
+                    if (ca.file.path.endsWith('jar')) {
+                        def ascfile = file(ca.file.path + '.asc')
+                        deployment.addArtifact(new DefaultPublishArtifact(ca.name, "jar.asc", "jar.asc", ca.classifier, null, ascfile))
+                    }
                 }
             }
 
@@ -267,6 +287,10 @@ uploadArchives {
                 developers project.ext.developers
             }
 
+            MavenPom ascPom = addFilter('asc') {artifact, file -> artifact.ext == "asc" }
+            ascPom.artifactId = 'crate-jdbc'
+            ascPom.groupId = project.group
+
             MavenPom pomJdbcStandalone = addFilter('crate-jdbc-standalone') {artifact, file ->
                 artifact.name == 'crate-jdbc-standalone'
             }
@@ -283,8 +307,8 @@ uploadArchives {
                 developers project.ext.developers
             }
 
-            repository(id: 'crate-jdbc', url: 'https://api.bintray.com/maven/crate/crate/crate-jdbc') {
-                authentication(userName: project.ext.bintrayUsername, password: project.ext.bintrayPassword)
+            repository(id: 'crate-jdbc', url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+                authentication(userName: project.ext.sonatypeUsername, password: project.ext.sonatypePassword)
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,7 @@ install {
 }
 
 project.ext.sonatypeUsername = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
-project.ext.sonatypeUsername = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
+project.ext.sonatypePassword = project.hasProperty('sonatypePassword') ? sonatypePassword : ""
 project.ext.url = 'https://crate.io'
 project.ext.scm = {
     url 'https://github.com/crate/crate-jdbc'

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -21,6 +21,10 @@ Consult the `compatibility notes`_ for additional information.
 Install
 =======
 
+Following the sunsetting of Bintray/JCenter, `crate-jdbc` has moved to `Maven Central`_.
+Versions < 2.6.0 will not be migrated. If you are using an older version, please
+consider upgrading, or building the artifacts manually.
+
 .. NOTE::
 
    These instructions show you how to do a conventional install.
@@ -30,12 +34,11 @@ Install
 
 There are two ways to install the driver.
 
-The regular CrateDB JDBC driver JAR files are hosted on `Bintray`_ and are
-available via `JCenter`_.
+The regular CrateDB JDBC driver JAR files are hosted on `Maven Central`_.
 
 Alternatively, you can download a single, standalone JAR file that bundles the
-driver dependencies. Use the `Bintray file navigator`_ to locate the version you
-want and download manually.
+driver dependencies. Use `The Maven Central Browser`_ to locate the version
+you want to download manually.
 
 .. CAUTION::
 
@@ -48,34 +51,10 @@ Set up as a dependency
 This section shows you how to set up the CrateDB JDBC driver as a
 dependency using Maven or Gradle; two popular build tools for Java projects.
 
-.. SEEALSO::
-
-   Select the blue *SET ME UP!* button located in the top right-hand corner of
-   the `Bintray overview page`_ for supplementary instructions.
-
 Maven
 -----
 
-If you're using `Maven`_, you first need to add the Bintray repository to your
-``pom.xml`` file:
-
-.. code-block:: xml
-
-    ...
-    <repositories>
-        ...
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>central</id>
-            <name>bintray</name>
-            <url>http://dl.bintray.com/crate/crate</url>
-        </repository>
-    </repositories>
-    ...
-
-Then add ``crate-jdb`` ass a dependency, like so:
+Add ``crate-jdb`` as a dependency, like so:
 
 .. code-block:: xml
 
@@ -93,14 +72,14 @@ Then add ``crate-jdb`` ass a dependency, like so:
 Gradle
 ------
 
-If you're using `Gradle`_, you first need to add the JCenter repository to your
+If you're using `Gradle`_, you first need to add the MavenCentral repository to your
 ``build.gradle`` file:
 
 .. code-block:: groovy
 
     repositories {
         ...
-        jcenter()
+        mavenCentral()
     }
 
 Then add ``crate-jdb`` as a dependency, like so:
@@ -118,15 +97,12 @@ Next steps
 Once the JDBC driver is set up, you probably want to :ref:`connect to CrateDB
 <connect>`.
 
-.. _Bintray file navigator: https://bintray.com/crate/crate/crate-jdbc/view/files/io/crate/crate-jdbc-standalone
-.. _Bintray overview page: https://bintray.com/crate/crate/crate-jdbc
-.. _Bintray: https://bintray.com/crate/crate/crate-jdbc
+.. _Maven Central: https://repo1.maven.org/maven2/io/crate/crate-jdbc/
+.. _The Maven Central Browser: : https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
 .. _compatibility notes: https://crate.io/docs/clients/jdbc/en/latest/compatibility.html
 .. _Gradle: https://gradle.org/
 .. _instructions on GitHub: https://github.com/crate/crate-jdbc/
 .. _Java 8: http://www.oracle.com/technetwork/java/javase/downloads/index.html
-.. _JCenter: https://bintray.com/bintray/jcenter
-.. _Maven: https://maven.apache.org/
 .. _OpenJDK: http://openjdk.java.net/projects/jdk8/
 .. _Oracle’s Java: http://www.java.com/en/download/help/mac_install.xml
 .. _SQuirreL: https://crate.io/a/use-cratedb-squirrel-basic-java-desktop-client/


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This is implementing uploading of crate-jdbc to Maven Central, following the sunsetting of Bintray/JCenter. The process is complicated by the fact that OSSRH (oss.sonatype.org) does quite a bit more checking of the deployed artifacts than bintray used to. It requires that:

- There is a `-javadoc.jar`
- There is a `-sources.jar`
- There are `.asc` signatures for all jars and poms

None of which worked in the previous setup (see https://dl.bintray.com/crate/crate/io/crate/crate-jdbc/2.6.0/). 

We had to adapt the gradle build to do this, which proved somewhat problematic. Gradle seems to favour usage of the `publish` plugin, whereas we were using the (simpler) `uploadArchives/mavenDeployer`, which refused to upload the `.asc` files, and required a hack to get them in. If someone with more Gradle knowledge can look at this and comment, that would be awesome.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
