### PR TITLE
Upgrade Sphinx dependency to match RTD default

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,4 +11,4 @@ sphinx-autobuild==0.6.0
 
 alabaster>=0.7,<0.8,!=0.7.5
 setuptools<41
-sphinx==1.7.4
+sphinx==1.8.5


### PR DESCRIPTION
this backport should fix the stale theme issues reported on https://github.com/crate/crate-jdbc/issues/342

if the CI checks pass, there should be no issue in merging this ([context](https://github.com/crate/crate-jdbc/issues/342#issuecomment-849599538))