### PR TITLE
Fix testExecuteBatchPreparedStatementFailBulkTypes

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -31,6 +31,12 @@ or::
 
     $ CRATE_URL=https://cdn.crate.io/downloads/releases/nightly/crate-0.58.0-201611210301-7d469f8.tar.gz ./gradlew test
 
+For debugging purposes, integration tests can be run against any CrateDB build.
+Build tar.gz file by running ./gradlew distTar from crate repository and set
+path to the generated file to the ``CRATE_PATH`` environment variable, e.g.::
+
+    $ CRATE_PATH=../crate/app/build/distributions/crate-4.7.0-SNAPSHOT-3edf1b4f2f2.tar.gz ./gradlew test
+
 Preparing a Release
 ===================
 

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/BaseIntegrationTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/BaseIntegrationTest.java
@@ -72,7 +72,12 @@ public abstract class BaseIntegrationTest extends RandomizedTest {
         if (downloadUrl != null) {
             builder = CrateTestCluster.fromURL(downloadUrl);
         } else {
-            builder = CrateTestCluster.fromVersion(getRandomServerVersion());
+            String filePath = System.getenv().get("CRATE_PATH");
+            if (filePath != null) {
+                builder = CrateTestCluster.fromFile(filePath);
+            } else {
+                builder = CrateTestCluster.fromVersion(getRandomServerVersion());
+            }
         }
         TEST_CLUSTER = builder.keepWorkingDir(false).build();
         TEST_CLUSTER.before();

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/ConnectionITest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/ConnectionITest.java
@@ -26,6 +26,7 @@ import io.crate.testing.CrateTestServer;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.postgresql.jdbc.CrateVersion;
 import org.postgresql.jdbc.PgDatabaseMetaData;
 import org.postgresql.util.PSQLException;
 
@@ -215,7 +216,10 @@ public class ConnectionITest extends BaseIntegrationTest {
             } catch (BatchUpdateException e) {
                 String msg = e.getMessage();
 
-                if (metaData.getCrateVersion().compareTo("4.2.0") >= 0) {
+                CrateVersion version = metaData.getCrateVersion(); // Don't query version several times.
+                if (version.compareTo("4.7.0") >= 0) {
+                    assertThat(msg, containsString("Cannot cast value `{}` to type `integer`"));
+                } else if (version.compareTo("4.2.0") >= 0) {
                     assertThat(msg, Matchers.allOf(
                             containsString("The type 'object' of the insert source "),
                             containsString("is not convertible to the type 'integer' of target column 'id'"))


### PR DESCRIPTION
Fixes [#66](https://github.com/crate/crate-alerts/issues/66) and [#348](https://github.com/crate/crate-jdbc/issues/348)
Also added an environment variable for debugging any local distribution.

see https://github.com/crate/crate/commit/2476b1dd1ffd6084f5e77fc2ea2c5d558c323ee9 - before that change `insert into(intcol) values(obj)` 
made `targetType = object` because of higher precedence and `checkSourceAndTargetColsForLengthAndTypesCompatibility` used to caught that `object.isConvertableTo(int) == false` and threw an exception with the old message.

Now `targetType = integer `because of target column higher precedence and `checkSourceAndTargetColsForLengthAndTypesCompatibility` doesn't throw an exception because int is convertible to int and cast exception happens somewhere further -> different exception message unexpected by `testExecuteBatchPreparedStatementFailBulkTypes`


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
