### PR TITLE
table catalog returns crate instead of doc

### DIFF
--- a/driver/test/java/io/crate/client/jdbc/integrationtests/MetaDataITest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/MetaDataITest.java
@@ -189,7 +189,7 @@ public class MetaDataITest extends BaseIntegrationTest {
         DatabaseMetaData metaData = conn.getMetaData();
         ResultSet rs = metaData.getPrimaryKeys("", "doc", "names");
         assertThat(rs.next(), is(true));
-        assertThat(rs.getString("TABLE_SCHEM"), is("doc"));
+        assertThat(rs.getString("TABLE_SCHEM"), is("crate"));
         assertThat(rs.getString("TABLE_NAME"), is("names"));
         assertThat(rs.getString("COLUMN_NAME"), is("id"));
     }
@@ -206,11 +206,11 @@ public class MetaDataITest extends BaseIntegrationTest {
         DatabaseMetaData metaData = conn.getMetaData();
         ResultSet rs = metaData.getPrimaryKeys("", null, "names");
         assertThat(rs.next(), is(true));
-        assertThat(rs.getString("TABLE_SCHEM"), is("doc"));
+        assertThat(rs.getString("TABLE_SCHEM"), is("crate"));
         assertThat(rs.getString("TABLE_NAME"), is("names"));
         assertThat(rs.getString("COLUMN_NAME"), is("id"));
         assertThat(rs.next(), is(true));
-        assertThat(rs.getString("TABLE_SCHEM"), is("my_schema"));
+        assertThat(rs.getString("TABLE_SCHEM"), is("crate"));
         assertThat(rs.getString("TABLE_NAME"), is("names"));
         assertThat(rs.getString("COLUMN_NAME"), is("id"));
     }


### PR DESCRIPTION
Fixes https://github.com/crate/crate-alerts/issues/304

Follow up to https://github.com/crate/crate/pull/12652

Query used to get PK

```
SELECT NULL AS "TABLE_CAT",
  tc.table_catalog AS "TABLE_SCHEM",
  tc.table_name AS "TABLE_NAME",
  kcu.column_name AS "COLUMN_NAME",
  kcu.ordinal_position AS "KEY_SEQ",
  tc.constraint_name AS "PK_NAME"
FROM information_schema.table_constraints tc
  INNER JOIN information_schema.key_column_usage kcu
  ON tc.constraint_name = kcu.constraint_name
  AND tc.table_catalog = kcu.table_catalog
WHERE tc.table_name = 'names'
ORDER BY "TABLE_SCHEM", "TABLE_NAME", "KEY_SEQ"
```