### PR TITLE
Modernize documentation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,4 +20,3 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -1,6 +1,22 @@
 ===============
-Developer Guide
+Developer guide
 ===============
+
+These instructions show you how to build the CrateDB JDBC driver from the
+source code, and how to invoke the test suite. For a conventional install
+(using pre-built JAR files), follow the `installation documentation`_.
+
+
+Acquire source
+==============
+
+Clone the repository::
+
+    $ git clone --recursive https://github.com/crate/crate-jdbc
+
+Change directory into the repository::
+
+    $ cd crate-jdbc
 
 Building
 ========
@@ -13,6 +29,20 @@ Gradle can be invoked like so::
 
 The first time this command is executed, Gradle is downloaded and bootstrapped
 for you automatically.
+
+Build a regular JAR file::
+
+    $ ./gradlew jar
+
+Or, build a JAR file that includes dependencies::
+
+    $ ./gradlew standaloneJar
+
+Afterwards you can find the JAR file in the ``build/lib`` directory.
+
+Note that building the JAR files requires your environment locale set to
+``UTF-8``.
+
 
 Testing
 =======
@@ -104,6 +134,7 @@ nothing special you need to do to get the live docs to update.
 
 .. _@crate/docs: https://github.com/orgs/crate/teams/docs
 .. _Gradle: https://gradle.org/
+.. _installation documentation: https://crate.io/docs/jdbc/en/latest/getting-started.html
 .. _ReStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://sphinx-doc.org/
 .. _Read the Docs: http://readthedocs.org/

--- a/README.rst
+++ b/README.rst
@@ -1,26 +1,18 @@
-===================
-CrateDB JDBC Driver
-===================
+==========================
+CrateDB legacy JDBC driver
+==========================
 
 |tests| |docs| |rtd| |maven-central|
 
 |
 
-A `JDBC`_ driver for `CrateDB`_.
+A `JDBC`_ driver for `CrateDB`_, based on the `PostgreSQL JDBC Driver`_.
 
-JDBC is a core API for Java 1.1 and later. It provides a standard set of
-interfaces to SQL-compliant databases.
+This is a `type 4 JDBC driver`_ written in pure Java. It communicates with the
+database using the `PostgreSQL Wire Protocol`_.
 
-This is a `type 4 JDBC driver`_. The driver is written in pure Java, and
-communicates with the database using the `PostgreSQL Wire Protocol`_.
-
-Prerequisites
-=============
-
-The CrateDB JDBC driver requires `Java 8`_, preferably update 20 or later. We
-recommend using `Oracle’s Java`_ on macOS and `OpenJDK`_ on Linux Systems.
-
-Consult the `compatibility notes`_ for additional information.
+`JDBC`_  is a standard Java API that provides common interfaces for accessing
+databases in Java.
 
 Installation
 ============
@@ -28,67 +20,43 @@ Installation
 The driver comes in two variants, available on Maven Central at `crate-jdbc`_
 and `crate-jdbc-standalone`_.
 
-The package specification is ``io.crate:crate-jdbc-standalone:2.6.0``.
+For a conventional install (using pre-built JAR files), follow the
+`installation documentation`_. For setting up a development sandbox, to build
+the JAR from source, please follow up reading the `developer guide`_.
 
-Build
-=====
+Documentation and help
+======================
 
-These instructions show you how to build the CrateDB JDBC driver from the
-source code. For a conventional install (using pre-built JAR files) follow the
-`getting started`_ documentation.
-
-Clone the repository::
-
-    $ git clone --recursive https://github.com/crate/crate-jdbc
-
-Change directory into the repository::
-
-    $ cd crate-jdbc
-
-Build a regular JAR file::
-
-    $ ./gradlew jar
-
-Or, build a JAR file that includes dependencies::
-
-    $ ./gradlew standaloneJar
-
-Afterwards you can find the JAR file in the ``build/lib`` directory.
-
-Note that building the JAR files requires your environment locale set to
-``UTF-8``.
+- `CrateDB legacy JDBC driver documentation`_
+- `CrateDB reference documentation`_
+- `JDBC tutorial`_
+- `JDBC API documentation`_
+- `Developer guide`_
+- `Contributing`_
+- Other `support channels`_
 
 Contributing
 ============
 
-This project is primarily maintained by Crate.io_, but we welcome community
-contributions!
-
-See the `developer docs`_ and the `contribution docs`_ for more information.
-
-Help
-====
-
-Looking for more help?
-
-- Read the `project docs`_
-- Check out our `support channels`_
+The CrateDB JDBC driver library is an open source project, and is `managed on
+GitHub`_. We appreciate contributions of any kind.
 
 
-.. _compatibility notes: https://crate.io/docs/clients/jdbc/en/latest/compatibility.html
-.. _contribution docs: CONTRIBUTING.rst
+.. _Contributing: CONTRIBUTING.rst
 .. _crate-jdbc: https://repo1.maven.org/maven2/io/crate/crate-jdbc/
 .. _crate-jdbc-standalone: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
 .. _Crate.io: http://crate.io/
 .. _CrateDB: https://github.com/crate/crate
-.. _developer docs: DEVELOP.rst
-.. _getting started: https://crate.io/docs/projects/crate-jdbc/getting-started.html
-.. _Java 8: http://www.oracle.com/technetwork/java/javase/downloads/index.html
-.. _JDBC: http://www.oracle.com/technetwork/java/overview-141217.html
-.. _OpenJDK: http://openjdk.java.net/projects/jdk8/
-.. _Oracle’s Java: http://www.java.com/en/download/help/mac_install.xml
+.. _CrateDB legacy JDBC driver documentation: https://crate.io/docs/projects/crate-jdbc/
+.. _CrateDB reference documentation: https://crate.io/docs/reference/
+.. _developer guide: DEVELOP.rst
+.. _installation documentation: https://crate.io/docs/jdbc/en/latest/getting-started.html
+.. _JDBC: https://en.wikipedia.org/wiki/Java_Database_Connectivity
+.. _JDBC API documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
+.. _JDBC tutorial: https://docs.oracle.com/javase/tutorial/jdbc/basics/
+.. _managed on GitHub: https://github.com/crate/crate-jdbc
+.. _PostgreSQL JDBC Driver: https://github.com/pgjdbc/pgjdbc
 .. _PostgreSQL Wire Protocol: https://crate.io/docs/crate/reference/en/latest/interfaces/postgres.html
-.. _project docs: https://crate.io/docs/projects/crate-jdbc/
 .. _support channels: https://crate.io/support/
 .. _type 4 JDBC driver: https://en.wikipedia.org/wiki/JDBC_driver#Type_4_driver_.E2.80.93_Database-Protocol_driver_.28Pure_Java_driver.29
 

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -1,8 +1,9 @@
 .. _compatibility:
+.. _compatibility-notes:
 
-=============
-Compatibility
-=============
+===================
+Compatibility notes
+===================
 
 .. rubric:: Table of contents
 

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -9,6 +9,27 @@ Connect to CrateDB
 .. contents::
    :local:
 
+
+.. _introduction:
+
+Introduction
+============
+
+The CrateDB JDBC driver provides the ``io.crate.client.jdbc.CrateDriver``
+class. JDBC 4.0 will initialise this class automatically if it is found on your
+`class path`_.
+
+.. NOTE::
+
+    For CrateDB versions 2.1.x and later, you must configure a database user
+    when connecting. Consult the `Connection Properties`_ section for more
+    information.
+
+.. SEEALSO::
+
+    Please also consult the JDBC documentation for general information about
+    how to `establish a connection using the DriverManager`_.
+
 .. _basics:
 
 The basics
@@ -17,22 +38,6 @@ The basics
 Connect to CrateDB using the ``DriverManager`` class, like so::
 
     Connection conn = DriverManager.getConnection("crate://localhost:5432/");
-
-.. NOTE::
-
-   For CrateDB versions 2.1.x and later, you must configure a database user
-   when connecting.
-
-   Consult the `Connection Properties`_ section for more information.
-
-.. SEEALSO::
-
-   Consult the `JDBC documentation`_ for general information about using the
-   ``DriverManager`` class.
-
-The CrateDB JDBC driver provides the ``io.crate.client.jdbc.CrateDriver``
-class. JDBC 4.0 will initialise this automatically if it is found on your
-`class path`_.
 
 .. _database-urls:
 
@@ -211,23 +216,19 @@ Next steps
 ==========
 
 Use the standard `JDBC API`_ documentation for the rest of your setup process.
+Also have a look at corresponding code :ref:`examples`.
 
-.. SEEALSO::
-
-   Check out the `sample application`_ (and the corresponding `documentation`_)
-   for a practical demonstration of this driver in use.
 
 .. _class path: https://docs.oracle.com/javase/tutorial/essential/environment/paths.html
 .. _client-side random load balancing: https://en.wikipedia.org/wiki/Load_balancing_(computing)#Client-side_random_load_balancing
 .. _database connection URL: https://docs.oracle.com/javase/tutorial/jdbc/basics/connecting.html#db_connection_url
 .. _Disabling auto-commit mode: https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html#disable_auto_commit
 .. _documentation: https://github.com/crate/crate-sample-apps/blob/master/java/documentation.md
+.. _establish a connection using the DriverManager: https://docs.oracle.com/javase/tutorial/jdbc/basics/connecting.html
 .. _failover: https://en.wikipedia.org/wiki/Failover
 .. _isolation level: https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html#transactions_data_integrity
 .. _JDBC API: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
-.. _JDBC documentation: https://docs.oracle.com/javase/tutorial/jdbc/basics/connecting.html
 .. _Read-only connections: https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#setReadOnly(boolean)
-.. _sample application: https://github.com/crate/crate-sample-apps/tree/master/java
 .. _Setting and rolling back to savepoints: https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html#set_roll_back_savepoints
 .. _Transactions: https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html
 .. _URL parameters: https://docs.oracle.com/javase/tutorial/jdbc/basics/connecting.html#db_connection_url

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -77,7 +77,7 @@ Then, add ``crate-jdbc`` as a dependency:
 .. code-block:: groovy
 
     dependencies {
-        compile 'io.crate:crate-jdbc:2.6.0'
+        implementation 'io.crate:crate-jdbc:2.6.0'
     }
 
 Next steps

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,8 +1,8 @@
-===============
-Getting started
-===============
+============
+Installation
+============
 
-Learn how to install and get started with the :ref:`CrateDB JDBC driver
+Learn how to install and get started with the :ref:`CrateDB legacy JDBC driver
 <index>`.
 
 .. rubric:: Table of contents
@@ -13,42 +13,37 @@ Learn how to install and get started with the :ref:`CrateDB JDBC driver
 Prerequisites
 =============
 
-The CrateDB JDBC driver requires `Java 8`_, preferably update 20 or later. We
+The CrateDB JDBC driver requires Java 8, preferably update 20 or later. We
 recommend using `Oracle’s Java`_ on macOS and `OpenJDK`_ on Linux Systems.
-
-Consult the :ref:`compatibility notes <compatibility>` for additional information.
+Please also consult the :ref:`compatibility-notes` for additional information.
 
 Install
 =======
 
-Following the sunsetting of Bintray/JCenter, `crate-jdbc`_ has moved to Maven Central.
-Versions < 2.6.0 will not be migrated. If you are using an older version, please
-consider upgrading, or building the artifacts manually.
+The driver comes in two variants, available on Maven Central at the
+`repository root folder`_.
 
-.. NOTE::
+- `crate-jdbc`_
 
-   These instructions show you how to do a conventional install.
+  The driver JAR, suitable to be used as a dependency in your project.
+
+- `crate-jdbc-standalone`_
+
+  A single, standalone JAR file, that bundles all the
+  driver dependencies, suitable to be used as a plugin for tools such as
+  `SQuirreL`_. This variant should not be used as a dependency in a Maven or
+  Gradle project.
+
+.. SEEALSO::
 
    To build the CrateDB JDBC driver from the source code, follow the
-   `instructions on GitHub`_.
-
-There are two ways to install the driver.
-
-The regular CrateDB JDBC driver JAR files `crate-jdbc`_ are hosted on Maven Central.
-
-Alternatively, you can download a single, standalone JAR file that bundles the
-driver dependencies, called `crate-jdbc-standalone`_.
-
-.. CAUTION::
-
-   The standalone JAR file should not be used in a Maven project. It does,
-   however, function nicely as a plugin for tools such as `SQuirreL`_.
+   `developer guide`_.
 
 Set up as a dependency
 ======================
 
 This section shows you how to set up the CrateDB JDBC driver as a
-dependency using Maven or Gradle; two popular build tools for Java projects.
+dependency using Maven or Gradle, two popular build tools for Java projects.
 
 Maven
 -----
@@ -57,37 +52,32 @@ Add ``crate-jdbc`` as a dependency, like so:
 
 .. code-block:: xml
 
-    ...
     <dependencies>
-        ...
         <dependency>
             <groupId>io.crate</groupId>
             <artifactId>crate-jdbc</artifactId>
-            <version>...</version>
+            <version>2.6.0</version>
         </dependency>
     </dependencies>
-    ...
 
 Gradle
 ------
 
-If you're using `Gradle`_, you first need to add the Maven Central repository to your
+If you're using `Gradle`_, you will need to add the Maven Central repository to your
 ``build.gradle`` file:
 
 .. code-block:: groovy
 
     repositories {
-        ...
         mavenCentral()
     }
 
-Then add ``crate-jdbc`` as a dependency, like so:
+Then, add ``crate-jdbc`` as a dependency:
 
 .. code-block:: groovy
 
     dependencies {
-        compile 'io.crate:crate-jdbc:...'
-        ...
+        compile 'io.crate:crate-jdbc:2.6.0'
     }
 
 Next steps
@@ -96,11 +86,13 @@ Next steps
 Once the JDBC driver is set up, you probably want to :ref:`connect to CrateDB
 <connect>`.
 
+
 .. _crate-jdbc: https://repo1.maven.org/maven2/io/crate/crate-jdbc/
 .. _crate-jdbc-standalone: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
+.. _developer guide: ../DEVELOP.rst
 .. _Gradle: https://gradle.org/
-.. _instructions on GitHub: https://github.com/crate/crate-jdbc/
-.. _Java 8: http://www.oracle.com/technetwork/java/javase/downloads/index.html
-.. _OpenJDK: http://openjdk.java.net/projects/jdk8/
-.. _Oracle’s Java: http://www.java.com/en/download/help/mac_install.xml
-.. _SQuirreL: https://crate.io/a/use-cratedb-squirrel-basic-java-desktop-client/
+.. _instructions on GitHub: https://github.com/crate/crate-jdbc
+.. _OpenJDK: https://openjdk.org/
+.. _Oracle’s Java: https://www.oracle.com/java/technologies/downloads/
+.. _repository root folder: https://repo1.maven.org/maven2/io/crate/
+.. _SQuirreL: https://crate.io/blog/use-cratedb-squirrel-basic-java-desktop-client

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,44 +1,66 @@
 .. _index:
 
-===================
-CrateDB JDBC Driver
-===================
-
-A `type 4 JDBC driver`_ for `CrateDB`_.
-
-`JDBC`_  is a standard Java API that provides a common interfaces for accessing
-databases in Java.
-
-.. NOTE::
-
-   This is a basic CrateDB driver reference.
-
-   Check out the `sample application`_ (and the corresponding `documentation`_)
-   for a practical demonstration of this driver in use.
-
-   For general help using JDBC, please consult the `JDBC
-   tutorial`_ or the `JDBC documentation`_.
-
-.. SEEALSO::
-
-   The CrateDB JDBC driver is an open source project and is `hosted on
-   GitHub`_.
+##########################
+CrateDB legacy JDBC driver
+##########################
 
 .. rubric:: Table of contents
 
+.. contents::
+    :local:
+    :depth: 1
+
+
+************
+Introduction
+************
+
+A `JDBC`_ driver for `CrateDB`_, based on the `PostgreSQL JDBC Driver`_.
+
+This is a `type 4 JDBC driver`_ written in pure Java. It communicates with the
+database using the `PostgreSQL Wire Protocol`_.
+
+`JDBC`_  is a standard Java API that provides common interfaces for accessing
+databases in Java.
+
+
+*************
+Documentation
+*************
+
+For general help about `JDBC`_, please consult the `JDBC tutorial`_ and the `JDBC
+API documentation`_.
+
 .. toctree::
-   :maxdepth: 2
+    :titlesonly:
 
-   getting-started
-   connect
-   appendices/index
+    getting-started
+    connect
+    appendices/index
 
+
+.. _examples:
+
+Examples
+========
+
+- The `Basic example for connecting to CrateDB using JDBC`_ demonstrates
+  CrateDB's PostgreSQL wire protocol compatibility by exercising a basic
+  example using both the vanilla pgJDBC Driver and the CrateDB JDBC Driver.
+- The `sample application`_ and the corresponding `sample application
+  documentation`_ demonstrate the use of the driver on behalf of an example
+  "guestbook" application, using `Spring Data JDBC`_.
+
+
+.. _Basic example for connecting to CrateDB using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
 .. _CrateDB: https://crate.io/products/cratedb/
-.. _documentation: https://github.com/crate/crate-sample-apps/blob/master/java/documentation.md
 .. _hosted on GitHub: https://github.com/crate/crate-jdbc/
-.. _JDBC tutorial: https://docs.oracle.com/javase/tutorial/jdbc/basics/index.html
-.. _JDBC documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
+.. _JDBC API documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
+.. _JDBC tutorial: https://docs.oracle.com/javase/tutorial/jdbc/basics/
 .. _JDBC: https://en.wikipedia.org/wiki/Java_Database_Connectivity
-.. _PostgreSQL Wire Protocol: https://www.postgresql.org/docs/current/static/protocol.html
-.. _sample application: https://github.com/crate/crate-sample-apps/tree/master/java
+.. _PostgreSQL JDBC Driver: https://github.com/pgjdbc/pgjdbc
+.. _PostgreSQL Wire Protocol: https://www.postgresql.org/docs/current/protocol.html
+.. _sample application: https://github.com/crate/crate-sample-apps/tree/main/java-spring
+.. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/main/java-spring/documentation.md
+.. _Spring Data JDBC: https://spring.io/projects/spring-data-jdbc/
 .. _type 4 JDBC driver: https://en.wikipedia.org/wiki/JDBC_driver#Type_4_driver_%E2%80%93_Database-Protocol_driver/Thin_Driver(Pure_Java_driver)


### PR DESCRIPTION
Hi,

following up on that we still need this driver for certain use-case scenarios around Apache Flink, this patch at least modernizes the documentation a bit. The preview can be inspected at https://crate-jdbc--364.org.readthedocs.build/en/364/.

- Naming things: Use "CrateDB legacy JDBC driver"
- Improve page layout, wording, and reading flow across the board
- Reduce unnecessary information about Java 8 and Bintray/JCenter
- Fix broken links

There will be a subsequent patch to clarify the purpose better within the documentation. This one is merely a maintenance patch without touching the content too much, just improving the structure.

With kind regards,
Andreas.


#### Backlog
- Clarify purpose of the driver.
- If we want people to use it easily, we should also add an example how to connect to CrateDB Cloud, like on the [CrateDB Python Client documentation](https://crate.io/docs/python/).
