### PR TITLE
Improve documentation to clarify purpose of the driver

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 CrateDB Data JDBC Driver
-Copyright 2013-2018 Crate.IO GmbH ("Crate")
+Copyright 2013-2023 Crate.IO GmbH ("Crate")
 
 
 Licensed to Crate.IO GmbH (referred to in this notice as "Crate") under one or

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -70,33 +70,7 @@ Consult the following table for CrateDB version compatibility notes:
 |                |                 | has no password set.                      |
 +----------------+-----------------+-------------------------------------------+
 
-.. _implementations:
 
-Implementation notes
-====================
-
-.. _jdbc-implementation:
-
-JDBC
-----
-
-The CrateDB JDBC driver follows the JDBC 4.1 standard.
-
-However, the following notes apply:
-
-- `ParameterMetaData`_ (e.g. as returned by `PreparedStatement`_) is not
-  supported.
-- `DataSource`_ is not supported.
-- `CallableStatement`_ is not supported, as CrateDB itself does not support
-  stored procedures.
-- `ResultSet`_ objects are read only (``TYPE_FORWARD_ONLY``, ``CONCUR_READ_ONLY``),
-  so changes to a ``ResultSet`` are not supported.
-
-.. _ParameterMetaData: https://docs.oracle.com/javase/8/docs/api/java/sql/ParameterMetaData.html
-.. _PreparedStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html
-.. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
-.. _CallableStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html
-.. _ResultSet: https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html
 .. _setSchema(): https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#setSchema-java.lang.String-
 .. _connection string: https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database
 .. _the PostgreSQL JDBC driver: https://jdbc.postgresql.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,8 @@ database using the `PostgreSQL Wire Protocol`_.
 databases in Java.
 
 
+.. _about:
+
 *****
 About
 *****
@@ -31,10 +33,21 @@ About
 Overview
 ========
 
-- This JDBC driver is needed in certain scenarios like the one outlined at
-  `Apache Kafka, Apache Flink, and CrateDB`_.
-- Officially, and for general purpose use, we recommend to use the canonical
-  `PostgreSQL JDBC Driver`_ instead.
+For general purpose use, we recommend to use the official `PostgreSQL JDBC
+Driver`_.
+
+*This* JDBC driver is needed in certain scenarios like the one outlined at
+`Apache Kafka, Apache Flink, and CrateDB`_. The background is that, when using
+the ``postgresql://`` JDBC driver prefix, the `Apache Flink JDBC Connector`_
+will implicitly select the corresponding dialect implementation for PostgreSQL.
+
+In turn, this will employ a few behaviours that strictly expect a PostgreSQL
+server on the other end, so that some operations will croak on databases
+offering wire-compatibility with PostgreSQL, but do not provide certain
+features like the `hstore`_ or `jsonb`_ extensions. Also, tools like `Dataiku`_
+need this driver to implement transaction commands like ``ROLLBACK`` as a
+no-op.
+
 
 .. _implementations:
 .. _jdbc-implementation:
@@ -87,17 +100,21 @@ Examples
   and `Flink example jobs for CrateDB`_.
 
 
+.. _Apache Flink JDBC Connector: https://github.com/apache/flink-connector-jdbc
 .. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 .. _Basic example for connecting to CrateDB and CrateDB Cloud using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
 .. _Build a data ingestion pipeline using Kafka, Flink, and CrateDB: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
 .. _CallableStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html
 .. _CrateDB: https://crate.io/products/cratedb/
+.. _Dataiku: https://www.dataiku.com/
 .. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
 .. _Flink example jobs for CrateDB: https://github.com/crate/cratedb-flink-jobs
 .. _hosted on GitHub: https://github.com/crate/crate-jdbc/
+.. _hstore: https://www.postgresql.org/docs/current/hstore.html
 .. _JDBC API documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
 .. _JDBC tutorial: https://docs.oracle.com/javase/tutorial/jdbc/basics/
 .. _JDBC: https://en.wikipedia.org/wiki/Java_Database_Connectivity
+.. _jsonb: https://www.postgresql.org/docs/current/datatype-json.html
 .. _ParameterMetaData: https://docs.oracle.com/javase/8/docs/api/java/sql/ParameterMetaData.html
 .. _pgjdbc driver fork: https://github.com/crate/pgjdbc
 .. _PostgreSQL JDBC Driver: https://github.com/pgjdbc/pgjdbc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,27 @@ Overview
   `Apache Kafka, Apache Flink, and CrateDB`_.
 - Officially, and for general purpose use, we recommend to use the canonical
   `PostgreSQL JDBC Driver`_ instead.
+
+.. _implementations:
+.. _jdbc-implementation:
+
+What's inside
+=============
+
+The driver is based upon a fork of the `PostgreSQL JDBC Driver`_, see
+`pgjdbc driver fork`_.
+
+Please take notice of the corresponding implementation notes:
+
+- `CallableStatement`_ is not supported, as CrateDB itself does not support
+  stored procedures.
+- `DataSource`_ is not supported.
+- `ParameterMetaData`_, e.g. as returned by `PreparedStatement`_, is not
+  supported.
+- `ResultSet`_ objects are read only (``TYPE_FORWARD_ONLY``, ``CONCUR_READ_ONLY``),
+  so changes to a ``ResultSet`` are not supported.
+
+
 *************
 Documentation
 *************
@@ -65,13 +86,19 @@ Examples
 
 .. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 .. _Basic example for connecting to CrateDB using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
+.. _CallableStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html
 .. _CrateDB: https://crate.io/products/cratedb/
+.. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
 .. _hosted on GitHub: https://github.com/crate/crate-jdbc/
 .. _JDBC API documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
 .. _JDBC tutorial: https://docs.oracle.com/javase/tutorial/jdbc/basics/
 .. _JDBC: https://en.wikipedia.org/wiki/Java_Database_Connectivity
+.. _ParameterMetaData: https://docs.oracle.com/javase/8/docs/api/java/sql/ParameterMetaData.html
+.. _pgjdbc driver fork: https://github.com/crate/pgjdbc
 .. _PostgreSQL JDBC Driver: https://github.com/pgjdbc/pgjdbc
 .. _PostgreSQL Wire Protocol: https://www.postgresql.org/docs/current/protocol.html
+.. _PreparedStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html
+.. _ResultSet: https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html
 .. _sample application: https://github.com/crate/crate-sample-apps/tree/main/java-spring
 .. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/main/java-spring/documentation.md
 .. _Spring Data JDBC: https://spring.io/projects/spring-data-jdbc/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,17 @@ database using the `PostgreSQL Wire Protocol`_.
 databases in Java.
 
 
+*****
+About
+*****
+
+Overview
+========
+
+- This JDBC driver is needed in certain scenarios like the one outlined at
+  `Apache Kafka, Apache Flink, and CrateDB`_.
+- Officially, and for general purpose use, we recommend to use the canonical
+  `PostgreSQL JDBC Driver`_ instead.
 *************
 Documentation
 *************
@@ -52,6 +63,7 @@ Examples
   "guestbook" application, using `Spring Data JDBC`_.
 
 
+.. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 .. _Basic example for connecting to CrateDB using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
 .. _CrateDB: https://crate.io/products/cratedb/
 .. _hosted on GitHub: https://github.com/crate/crate-jdbc/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,9 +76,9 @@ API documentation`_.
 Examples
 ========
 
-- The `Basic example for connecting to CrateDB using JDBC`_ demonstrates
-  CrateDB's PostgreSQL wire protocol compatibility by exercising a basic
-  example using both the vanilla pgJDBC Driver and the CrateDB JDBC Driver.
+- The `Basic example for connecting to CrateDB and CrateDB Cloud using JDBC`_
+  demonstrates CrateDB's PostgreSQL wire protocol compatibility by exercising a
+  basic example using both the vanilla pgJDBC Driver and the CrateDB JDBC Driver.
 - The `sample application`_ and the corresponding `sample application
   documentation`_ demonstrate the use of the driver on behalf of an example
   "guestbook" application, using `Spring Data JDBC`_.
@@ -88,7 +88,7 @@ Examples
 
 
 .. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
-.. _Basic example for connecting to CrateDB using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
+.. _Basic example for connecting to CrateDB and CrateDB Cloud using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
 .. _Build a data ingestion pipeline using Kafka, Flink, and CrateDB: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
 .. _CallableStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html
 .. _CrateDB: https://crate.io/products/cratedb/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,13 +82,18 @@ Examples
 - The `sample application`_ and the corresponding `sample application
   documentation`_ demonstrate the use of the driver on behalf of an example
   "guestbook" application, using `Spring Data JDBC`_.
+- The article `Build a data ingestion pipeline using Kafka, Flink, and CrateDB`_,
+  and the accompanying repositories `Apache Kafka, Apache Flink, and CrateDB`_
+  and `Flink example jobs for CrateDB`_.
 
 
 .. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 .. _Basic example for connecting to CrateDB using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
+.. _Build a data ingestion pipeline using Kafka, Flink, and CrateDB: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
 .. _CallableStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html
 .. _CrateDB: https://crate.io/products/cratedb/
 .. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
+.. _Flink example jobs for CrateDB: https://github.com/crate/cratedb-flink-jobs
 .. _hosted on GitHub: https://github.com/crate/crate-jdbc/
 .. _JDBC API documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
 .. _JDBC tutorial: https://docs.oracle.com/javase/tutorial/jdbc/basics/


### PR DESCRIPTION
Following up on GH-364, this patch aims to:

- Clarify the purpose of this "legacy" driver (f615472103)
  - Describe why it is still needed in a few cases.
  - Also add the recommendation to use the official driver in other cases.

- Make "implementation notes" more prominent (b64ff63c5d)
  In order to better educate users about "what's inside", this refactors a section of the documentation from the appendix to the front page.

- Add example about Apache Kafka, Apache Flink, and CrateDB (6a6912e66c)