### PR TITLE
Documentation: Add a few more information bits about driver differences

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
 from crate.theme.rtd.conf.jdbc import *
 
 exclude_patterns = ['.crate-docs/**', 'requirements.txt']
+
+linkcheck_anchors_ignore = [
+    r"diff-.*",
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ Connect to CrateDB Cloud.
     connectionProps.put("password", "<PASSWORD>");
     connectionProps.put("tcpKeepAlive", true);
 
-    Connection conn = DriverManager.getConnection("jdbc:crate://example.aks1.westeurope.azure.cratedb.net:5432/", connectionProps);
+    Connection conn = DriverManager.getConnection("jdbc:crate://example.aks1.westeurope.azure.cratedb.net:5432/?user=crate", connectionProps);
 
 
 .. _details:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,9 +16,11 @@ Introduction
 ************
 
 A `JDBC`_ driver for `CrateDB`_, based on the `PostgreSQL JDBC Driver`_.
+It can be used with CrateDB version 0.38.0 and newer.
 
-This is a `type 4 JDBC driver`_ written in pure Java. It communicates with the
-database using the `PostgreSQL Wire Protocol`_.
+This is a `JDBC Type 4 driver`_, adhering to the `JDBC 4.1 specification`_. It
+is written in pure Java, and communicates with the database using the
+`PostgreSQL Wire Protocol`_.
 
 `JDBC`_  is a standard Java API that provides common interfaces for accessing
 databases in Java.
@@ -73,7 +75,7 @@ the ``postgresql://`` JDBC driver prefix, the `Apache Flink JDBC Connector`_
 will implicitly select the corresponding dialect implementation for PostgreSQL.
 
 In turn, this will employ a few behaviours that strictly expect a PostgreSQL
-server on the other end, so that some operations will croak on databases
+server on the other end, so that some operations will fail on databases
 offering wire-compatibility with PostgreSQL, but do not provide certain
 features like the `hstore`_ or `jsonb`_ extensions. Also, tools like `Dataiku`_
 need this driver to implement transaction commands like ``ROLLBACK`` as a
@@ -98,6 +100,12 @@ Please take notice of the corresponding implementation notes:
   supported.
 - `ResultSet`_ objects are read only (``TYPE_FORWARD_ONLY``, ``CONCUR_READ_ONLY``),
   so changes to a ``ResultSet`` are not supported.
+- DDL and DML statements are supported through adjustments to the
+  `PgPreparedStatement`_ and `PgStatement`_ interfaces.
+
+To learn further details about the compatibility with JDBC and PostgreSQL
+features, see the specific code changes to the `PgConnection`_,
+`PgDatabaseMetaData`_, and `PgResultSet`_ classes.
 
 
 *************
@@ -175,13 +183,20 @@ The project is licensed under the terms of the Apache 2.0 license, like
 .. _Flink example jobs for CrateDB: https://github.com/crate/cratedb-flink-jobs
 .. _hosted on GitHub: https://github.com/crate/crate-jdbc/
 .. _hstore: https://www.postgresql.org/docs/current/hstore.html
+.. _JDBC: https://en.wikipedia.org/wiki/Java_Database_Connectivity
+.. _JDBC 4.1 specification: https://download.oracle.com/otn-pub/jcp/jdbc-4_1-mrel-spec/jdbc4.1-fr-spec.pdf
 .. _JDBC API documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
 .. _JDBC tutorial: https://docs.oracle.com/javase/tutorial/jdbc/basics/
-.. _JDBC: https://en.wikipedia.org/wiki/Java_Database_Connectivity
+.. _JDBC Type 4 driver: https://en.wikipedia.org/wiki/JDBC_driver#Type_4_driver_%E2%80%93_Database-Protocol_driver/Thin_Driver(Pure_Java_driver)
 .. _jsonb: https://www.postgresql.org/docs/current/datatype-json.html
 .. _LICENSE: https://github.com/crate/crate-jdbc/blob/master/LICENSE
 .. _ParameterMetaData: https://docs.oracle.com/javase/8/docs/api/java/sql/ParameterMetaData.html
 .. _pgjdbc driver fork: https://github.com/crate/pgjdbc
+.. _PgConnection: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-8ee30bec696495ec5763a3e1c1b216776efc124729f72e18dbaa35064af0aef0
+.. _PgDatabaseMetaData: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-0571f8ac3385a7f7bb34e5c77f8afd24810311506989379c2e85c6c16eea6ce4
+.. _PgResultSet: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-7e93771092eab9084402e3c7c81319a1f037febdc7614264329bd29f11d39ef2
+.. _PgPreparedStatement: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-d4946409bd7c59e525f34b4c974a3df76638dc84adc060cc5d13d5409c6aeb21
+.. _PgStatement: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-2abcc60e1b1ef8eeadd6372bf7afd0c0ebae0ebd691b0965fc914fea794eb6d0
 .. _PostgreSQL JDBC Driver: https://github.com/pgjdbc/pgjdbc
 .. _PostgreSQL Wire Protocol: https://www.postgresql.org/docs/current/protocol.html
 .. _PreparedStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html
@@ -189,4 +204,3 @@ The project is licensed under the terms of the Apache 2.0 license, like
 .. _sample application: https://github.com/crate/crate-sample-apps/tree/main/java-spring
 .. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/main/java-spring/documentation.md
 .. _Spring Data JDBC: https://spring.io/projects/spring-data-jdbc/
-.. _type 4 JDBC driver: https://en.wikipedia.org/wiki/JDBC_driver#Type_4_driver_%E2%80%93_Database-Protocol_driver/Thin_Driver(Pure_Java_driver)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,30 +82,20 @@ need this driver to implement transaction commands like ``ROLLBACK`` as a
 no-op.
 
 
-.. _implementations:
-.. _jdbc-implementation:
+.. _differences:
 
-What's inside
-=============
+Differences
+===========
 
-The driver is based upon a fork of the `PostgreSQL JDBC Driver`_, see
-`pgjdbc driver fork`_.
+The driver is based upon a fork of the `PostgreSQL JDBC Driver`_, see `pgjdbc
+driver fork`_. On a high-level perspective, this list enumerates a few
+behavioral differences.
 
-Please take notice of the corresponding implementation notes:
+- The CrateDB driver deserializes objects to a Map, the official one treats them as JSON.
+- A few metadata functions have been adjusted to better support CrateDB's type system.
 
-- `CallableStatement`_ is not supported, as CrateDB itself does not support
-  stored procedures.
-- `DataSource`_ is not supported.
-- `ParameterMetaData`_, e.g. as returned by `PreparedStatement`_, is not
-  supported.
-- `ResultSet`_ objects are read only (``TYPE_FORWARD_ONLY``, ``CONCUR_READ_ONLY``),
-  so changes to a ``ResultSet`` are not supported.
-- DDL and DML statements are supported through adjustments to the
-  `PgPreparedStatement`_ and `PgStatement`_ interfaces.
+Read up on further details at the :ref:`internals` section.
 
-To learn further details about the compatibility with JDBC and PostgreSQL
-features, see the specific code changes to the `PgConnection`_,
-`PgDatabaseMetaData`_, and `PgResultSet`_ classes.
 
 
 *************
@@ -121,6 +111,7 @@ API documentation`_.
     getting-started
     connect
     appendices/index
+    internals
 
 
 .. _examples:
@@ -173,12 +164,10 @@ The project is licensed under the terms of the Apache 2.0 license, like
 .. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 .. _Basic example for connecting to CrateDB and CrateDB Cloud using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
 .. _Build a data ingestion pipeline using Kafka, Flink, and CrateDB: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
-.. _CallableStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html
 .. _CrateDB: https://crate.io/products/cratedb/
 .. _CrateDB source: https://github.com/crate/crate
 .. _Create an issue: https://github.com/crate/crate-jdbc/issues
 .. _Dataiku: https://www.dataiku.com/
-.. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
 .. _development sandbox: https://github.com/crate/crate-jdbc/blob/master/DEVELOP.rst
 .. _Flink example jobs for CrateDB: https://github.com/crate/cratedb-flink-jobs
 .. _hosted on GitHub: https://github.com/crate/crate-jdbc/
@@ -190,17 +179,9 @@ The project is licensed under the terms of the Apache 2.0 license, like
 .. _JDBC Type 4 driver: https://en.wikipedia.org/wiki/JDBC_driver#Type_4_driver_%E2%80%93_Database-Protocol_driver/Thin_Driver(Pure_Java_driver)
 .. _jsonb: https://www.postgresql.org/docs/current/datatype-json.html
 .. _LICENSE: https://github.com/crate/crate-jdbc/blob/master/LICENSE
-.. _ParameterMetaData: https://docs.oracle.com/javase/8/docs/api/java/sql/ParameterMetaData.html
 .. _pgjdbc driver fork: https://github.com/crate/pgjdbc
-.. _PgConnection: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-8ee30bec696495ec5763a3e1c1b216776efc124729f72e18dbaa35064af0aef0
-.. _PgDatabaseMetaData: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-0571f8ac3385a7f7bb34e5c77f8afd24810311506989379c2e85c6c16eea6ce4
-.. _PgResultSet: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-7e93771092eab9084402e3c7c81319a1f037febdc7614264329bd29f11d39ef2
-.. _PgPreparedStatement: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-d4946409bd7c59e525f34b4c974a3df76638dc84adc060cc5d13d5409c6aeb21
-.. _PgStatement: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-2abcc60e1b1ef8eeadd6372bf7afd0c0ebae0ebd691b0965fc914fea794eb6d0
 .. _PostgreSQL JDBC Driver: https://github.com/pgjdbc/pgjdbc
 .. _PostgreSQL Wire Protocol: https://www.postgresql.org/docs/current/protocol.html
-.. _PreparedStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html
-.. _ResultSet: https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html
 .. _sample application: https://github.com/crate/crate-sample-apps/tree/main/java-spring
 .. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/main/java-spring/documentation.md
 .. _Spring Data JDBC: https://spring.io/projects/spring-data-jdbc/

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1,0 +1,40 @@
+.. _internals:
+
+#########
+Internals
+#########
+
+
+.. _implementations:
+.. _jdbc-implementation:
+
+What's inside
+=============
+
+Please take notice of the corresponding implementation notes:
+
+- `CallableStatement`_ is not supported, as CrateDB itself does not support
+  stored procedures.
+- `DataSource`_ is not supported.
+- `ParameterMetaData`_, e.g. as returned by `PreparedStatement`_, is not
+  supported.
+- `ResultSet`_ objects are read only (``TYPE_FORWARD_ONLY``, ``CONCUR_READ_ONLY``),
+  so changes to a ``ResultSet`` are not supported.
+- DDL and DML statements are supported through adjustments to the
+  `PgPreparedStatement`_ and `PgStatement`_ interfaces.
+
+To learn further details about the compatibility with JDBC and PostgreSQL
+features, see the specific code changes to the `PgConnection`_,
+`PgDatabaseMetaData`_, and `PgResultSet`_ classes.
+
+
+.. _CallableStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html
+.. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
+.. _ParameterMetaData: https://docs.oracle.com/javase/8/docs/api/java/sql/ParameterMetaData.html
+.. _PgConnection: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-8ee30bec696495ec5763a3e1c1b216776efc124729f72e18dbaa35064af0aef0
+.. _PgDatabaseMetaData: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-0571f8ac3385a7f7bb34e5c77f8afd24810311506989379c2e85c6c16eea6ce4
+.. _PgResultSet: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-7e93771092eab9084402e3c7c81319a1f037febdc7614264329bd29f11d39ef2
+.. _PgPreparedStatement: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-d4946409bd7c59e525f34b4c974a3df76638dc84adc060cc5d13d5409c6aeb21
+.. _PgStatement: https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...crate:pgjdbc:REL42.2.5_crate?expand=1#diff-2abcc60e1b1ef8eeadd6372bf7afd0c0ebae0ebd691b0965fc914fea794eb6d0
+.. _PreparedStatement: https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html
+.. _ResultSet: https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html


### PR DESCRIPTION
Other than bringing in a few updates to the "What's inside" section, coming from GH-368, this patch points the dear reader to specific spots in the code base of the pgJDBC fork, where several details have been addressed to support CrateDB instead of a real PostgreSQL server.

/cc @seut