### PR TITLE
Prepare release 2.7.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data JDBC Client
 Unreleased
 ==========
 
+2023/04/18 2.7.0
+================
+
 - Changed ``getPrimaryKeys()`` SQL stmt to use the table schema as the schema
   instead of the table catalog. This fixes compatibility with CrateDB >= 5.1.0
   as all catalog fields at the ``information_schema.tables`` schema expose now

--- a/driver/main/java/io/crate/client/jdbc/CrateDriverVersion.java
+++ b/driver/main/java/io/crate/client/jdbc/CrateDriverVersion.java
@@ -24,8 +24,8 @@ package io.crate.client.jdbc;
 
 public class CrateDriverVersion {
 
-    private static final boolean SNAPSHOT = true;
-    static final CrateDriverVersion CURRENT = new CrateDriverVersion(20601, SNAPSHOT);
+    private static final boolean SNAPSHOT = false;
+    static final CrateDriverVersion CURRENT = new CrateDriverVersion(20700, SNAPSHOT);
 
     private final int id;
     final byte major;


### PR DESCRIPTION
### About
Running a new release, in order to ship improvements from `pgjdbc` fork.

### References
- https://github.com/crate/crate-jdbc/pull/378
- https://github.com/crate/pgjdbc/pull/38