### PR TITLE
Use in-memory pgp keys provided by ENV vars for signing JAR files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,9 @@ artifacts {
 }
 
 task signJars (type : Sign, dependsOn: [shadedJar, standaloneJar, javadocJar, javadocJarStandalone, sourceJar, sourceJarStandalone]) {
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign configurations.archives
 }
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Instead of using a ~/.gradle/gradle.properties file holding the sensitive information of the private key and password for creating signatures of releasable JAR files, use ENV vars.

See also https://github.com/crate/infrastructure/pull/3015.