### PR TITLE
Use in-memory keys for signing and modernize gradle tasks 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,15 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -109,7 +109,10 @@ the Maven repository.
 
 However, if you'd like to do this manually, you can run::
 
-    $ ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+    $ ./gradlew clean ublishToSonatype closeAndReleaseSonatypeStagingRepository
+
+This requires you to have the required (ascii) key and password configured,
+see `Build, sign and publish the JAR files locally`_.
 
 Archiving Docs Versions
 -----------------------

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -43,6 +43,24 @@ Afterwards you can find the JAR file in the ``build/lib`` directory.
 Note that building the JAR files requires your environment locale set to
 ``UTF-8``.
 
+Build, sign and publish the JAR files locally
+---------------------------------------------
+
+To test the build and publishing process, you can build, sign and publish the
+JAR files locally::
+
+    $ ./gradlew publishJdbcPublicationToMavenLocal
+
+or for the standalong version which includes dependencies::
+
+    $ ./gradlew publishJdbcStandalonePublicationToMavenLocal
+
+For the signing to work, you need to have the required (ascii) key and password
+configured under the following ENVIRONMENT variables:
+
+ - `ORG_GRADLE_PROJECT_signingKey`          <- the private key in ascii format
+ - `ORG_GRADLE_PROJECT_signingPassword`     <- the password for the private key
+
 
 Testing
 =======
@@ -91,7 +109,7 @@ the Maven repository.
 
 However, if you'd like to do this manually, you can run::
 
-    $ ./gradlew uploadArchives
+    $ ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
 
 Archiving Docs Versions
 -----------------------

--- a/build.gradle
+++ b/build.gradle
@@ -1,47 +1,41 @@
-
-buildscript {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
-        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0'
-    }
+plugins {
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
+    id "maven-publish"
+    id "signing"
 }
 
-import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
-group = "io.crate"
-
-apply plugin: 'io.codearte.nexus-staging'
 
 allprojects {
     apply plugin: 'idea'
-    apply plugin: 'java'
-    apply plugin: 'maven'
-    apply plugin: 'signing'
-
+    apply plugin: "java-library"
     repositories {
         mavenCentral()
         gradlePluginPortal()
     }
-
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
 }
 
+group = "io.crate"
+
 dependencies {
-    compile project(':pg')
-    testCompile 'io.crate:crate-testing:0.10.0'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile 'junit:junit:4.12'
-    testCompile ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.1') {
+    implementation project(':pg')
+    testImplementation 'io.crate:crate-testing:0.9.1'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.1') {
         exclude group: 'junit', module: 'junit'
     }
-    testCompile ("org.mockito:mockito-core:2.23.4") {
+    testImplementation ("org.mockito:mockito-core:2.23.4") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
     }
 }
 
@@ -61,8 +55,8 @@ sourceSets {
     }
 }
 
-task getVersion(dependsOn: [classes]) {
-    doLast {
+task getVersion(dependsOn: [compileJava]) {
+    doFirst {
         def stdout = new ByteArrayOutputStream()
         javaexec {
             classpath = sourceSets.main.runtimeClasspath
@@ -72,7 +66,7 @@ task getVersion(dependsOn: [classes]) {
         ext.gitTag = "git describe".execute().in.text.trim()
         ext.version = stdout.toString().trim().split(" ")[1].replace(',','').trim()
 
-        if (!gradle.taskGraph.hasTask(uploadArchives)) {
+        if (!gradle.taskGraph.hasTask(publishToSonatype)) {
             ext.version = version + "-" + "git rev-parse --short HEAD".execute().in.text.trim()
         }
         project.version = version
@@ -82,42 +76,38 @@ task getVersion(dependsOn: [classes]) {
     }
 }
 
-task shadedJar(type: ShadowJar, dependsOn: [getVersion]) {
-    baseName 'crate-jdbc'
-    classifier ''
+shadowJar.dependsOn([getVersion])
+shadowJar {
+    archiveClassifier.set('')
     duplicatesStrategy 'fail'
-    configurations = [project.configurations.compile]
+    configurations = [project.configurations.compileClasspath]
     dependencies {
         include(project(':pg'))
     }
     doFirst {
         from sourceSets.main.output
-    }
-    doLast {
         manifest {
-            attributes("Implementation-Title": "Crate.IO JDBC Driver", "Implementation-Version": project.version)
+            attributes("Implementation-Title": "CrateDB JDBC Driver", "Implementation-Version": project.version)
         }
     }
+
     relocate 'org.postgresql', 'io.crate.shade.org.postgresql'
 }
 
-jar.dependsOn(dependsOn: [shadedJar])
+jar.dependsOn(dependsOn: [shadowJar])
 jar {
-    baseName 'crate-jdbc'
-    actions = [] // Do nothing, build shadedJar instead
+    actions = [] // Do nothing, build shadowJar instead
 }
 
 task standaloneJar(type: ShadowJar, dependsOn: [getVersion]) {
-    baseName 'crate-jdbc-standalone'
-    classifier ''
+    archiveBaseName.set('crate-jdbc-standalone')
+    archiveClassifier.set('')
     duplicatesStrategy 'fail'
-    configurations = [project.configurations.compile]
+    configurations = [project.configurations.compileClasspath]
     doFirst {
         from sourceSets.main.output
-    }
-    doLast {
         manifest {
-            attributes("Implementation-Title": "Crate.IO JDBC Driver (Standalone)", "Implementation-Version": project.version)
+            attributes("Implementation-Title": "CrateDB JDBC Driver (Standalone)", "Implementation-Version": project.version)
         }
     }
     // Crate JDBC dependencies
@@ -133,183 +123,122 @@ task standaloneJar(type: ShadowJar, dependsOn: [getVersion]) {
     relocate 'com.ongres', 'io.crate.shade.com.ongres'
 }
 
-
-task myJavadocs(type: Javadoc, dependsOn: processResources) {
-    classpath = configurations.compile
-    source = sourceSets.main.allJava
-}
-
-task javadocJar (type: Jar, dependsOn: [getVersion, myJavadocs]) {
-    baseName 'crate-jdbc'
-    classifier = 'javadoc'
-    from myJavadocs.destinationDir
-    doLast {
+task javadocJar(type: Jar, dependsOn: [getVersion, javadoc]) {
+    archiveClassifier.set("javadoc")
+    from javadoc.destinationDir
+    doFirst {
         manifest {
-            attributes("Implementation-Title": "Crate.IO JDBC Driver", "Implementation-Version": project.version)
+            attributes("Implementation-Title": "CrateDB JDBC Driver", "Implementation-Version": project.version)
         }
     }
 }
 
-task javadocJarStandalone (type: Jar, dependsOn: [getVersion, myJavadocs]) {
-    baseName 'crate-jdbc-standalone'
-    classifier = 'javadoc'
-    from myJavadocs.destinationDir
-    doLast {
+task javadocJarStandalone (type: Jar, dependsOn: [getVersion, javadoc]) {
+    archiveBaseName.set('crate-jdbc-standalone')
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+    doFirst {
         manifest {
-            attributes("Implementation-Title": "Crate.IO JDBC Driver (Standalone)", "Implementation-Version": project.version)
+            attributes("Implementation-Title": "CrateDB JDBC Driver (Standalone)", "Implementation-Version": project.version)
         }
     }
 }
 
-
-task sourceJar (type : Jar, dependsOn: [getVersion]) {
-    baseName 'crate-jdbc'
-    classifier = 'sources'
+task sourcesJar (type : Jar, dependsOn: [getVersion]) {
+    archiveClassifier.set('sources')
     from sourceSets.main.allSource
-    doLast {
+    doFirst {
         manifest {
-            attributes("Implementation-Title": "Crate.IO JDBC Driver", "Implementation-Version": project.version)
+            attributes("Implementation-Title": "CrateDB JDBC Driver", "Implementation-Version": project.version)
         }
     }
 }
 
-task sourceJarStandalone (type : Jar, dependsOn: [getVersion]) {
-    baseName 'crate-jdbc-standalone'
-    classifier = 'sources'
+task sourcesJarStandalone (type : Jar, dependsOn: [getVersion]) {
+    archiveBaseName.set('crate-jdbc-standalone')
+    archiveClassifier.set('sources')
     from sourceSets.main.allSource
-    doLast {
+    doFirst {
         manifest {
-            attributes("Implementation-Title": "Crate.IO JDBC Driver (Standalone)", "Implementation-Version": project.version)
+            attributes("Implementation-Title": "CrateDB JDBC Driver (Standalone)", "Implementation-Version": project.version)
         }
     }
 }
 
 
 artifacts {
-    archives shadedJar
+    archives shadowJar
     archives standaloneJar
     archives javadocJar
     archives javadocJarStandalone
-    archives sourceJar
-    archives sourceJarStandalone
+    archives sourcesJar
+    archives sourcesJarStandalone
 }
 
-task signJars (type : Sign, dependsOn: [shadedJar, standaloneJar, javadocJar, javadocJarStandalone, sourceJar, sourceJarStandalone]) {
-    sign configurations.archives
-}
-
-install.dependsOn([shadedJar, standaloneJar, javadocJar, javadocJarStandalone, sourceJar, sourceJarStandalone])
-install {
-    repositories {
-        mavenInstaller {
-            addFilter('crate-jdbc') {artifact, file ->
-                artifact.name == 'crate-jdbc'
-            }
-            addFilter('crate-jdbc-standalone') {artifact, file ->
-                artifact.name == 'crate-jdbc-standalone'
-            }
-            pom('crate-jdbc-standalone').whenConfigured {
-                it.dependencies.clear()
-            }
-        }
-    }
-}
 
 project.ext.sonatypeUsername = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
 project.ext.sonatypePassword = project.hasProperty('sonatypePassword') ? sonatypePassword : ""
 project.ext.url = 'https://crate.io'
 project.ext.scm = {
-    url 'https://github.com/crate/crate-jdbc'
-    connection 'scm:git:git://github.com/crate/crate-jdbc.git'
-    developerConnection 'scm:git:ssh:git@github.com:crate/crate-jdbc.git'
+    url = 'https://github.com/crate/crate-jdbc'
+    connection = 'scm:git:git://github.com/crate/crate-jdbc.git'
+    developerConnection = 'scm:git:ssh:git@github.com:crate/crate-jdbc.git'
 }
 project.ext.licenses = {
     license {
-        name 'The Apache Software License, Version 2.0'
-        url 'http://www.apache.org/license/LICENSE-2.0.txt'
-        distribution 'repo'
+        name = 'The Apache Software License, Version 2.0'
+        url = 'http://www.apache.org/license/LICENSE-2.0.txt'
+        distribution = 'repo'
     }
 }
 project.ext.developers = {
     developer {
-        id 'crate'
-        name 'Crate Developers'
-        email 'office@crate.io'
+        id = 'crate'
+        name = 'Crate Developers'
+        email = 'office@crate.io'
     }
 }
 
-uploadArchives.dependsOn([signJars])
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment {
-                MavenDeployment deployment -> signing.signPom(deployment)
-                if (project.ext.sonatypeUsername.length() == 0 || project.ext.sonatypePassword.length() == 0) {
-                    throw new StopExecutionException("uploadArchives cannot be called without maven username and password")
-                }
-                // This is a (very) un-pretty way of attaching the asc files as artifacts to the deployment.
-                // The mavenDeployer is pretty old, not documented very well - and does not pick up .asc files.
-                // Here we're slightly abusing the system and creating "fake" .asc artifacts for each .jar file,
-                // because we know for certain that if we got there, the asc files must exist.
-                // If we don't do this, Sonatype will not allow promotion to maven central.
-                artifacts.each { ca ->
-                    if (ca.file.path.endsWith('jar')) {
-                        def ascfile = file(ca.file.path + '.asc')
-                        deployment.addArtifact(new DefaultPublishArtifact(ca.name, "jar.asc", "jar.asc", ca.classifier, null, ascfile))
-                    }
-                }
-            }
-
-            MavenPom pomJdbc = addFilter('crate-jdbc') {artifact, file ->
-                artifact.name == 'crate-jdbc'
-            }
-
-            pomJdbc.whenConfigured { pom ->
-                pom.dependencies.clear()
-                subprojects.findAll().each {
-                    if (it.hasProperty('install')) {
-                        pom.dependencies.addAll(
-                            it.install.repositories.mavenInstaller.pom.getEffectivePom().dependencies.findAll()
-                        )
-                    }
-                }
-            }
-
-            pomJdbc.project {
-                artifactId 'crate-jdbc'
-                name 'crate-jdbc'
-                description 'Crate.IO JDBC Driver'
-                url project.ext.url
-                scm project.ext.scm
+publishing {
+    publications {
+        jdbc(MavenPublication) {
+            artifactId = 'crate-jdbc'
+            artifact shadowJar
+            artifact sourcesJar
+            artifact javadocJar
+            version = project.version
+            pom {
+                name = "crate-jdbc"
+                description = "CrateDB JDBC Driver"
+                url = project.ext.url
                 licenses project.ext.licenses
                 developers project.ext.developers
-            }
-
-            MavenPom ascPom = addFilter('asc') {artifact, file -> artifact.ext == "asc" }
-            ascPom.artifactId = 'crate-jdbc'
-            ascPom.groupId = project.group
-
-            MavenPom pomJdbcStandalone = addFilter('crate-jdbc-standalone') {artifact, file ->
-                artifact.name == 'crate-jdbc-standalone'
-            }
-            pomJdbcStandalone.whenConfigured {
-                it.dependencies.clear()
-            }
-            pomJdbcStandalone.project {
-                artifactId 'crate-jdbc-standalone'
-                name 'crate-jdbc-standalone'
-                description 'Crate.IO JDBC Driver (Standalone)'
-                url project.ext.url
                 scm project.ext.scm
+            }
+        }
+        jdbcStandalone(MavenPublication) {
+            artifactId = 'crate-jdbc-standalone'
+            artifact standaloneJar
+            artifact javadocJarStandalone
+            artifact sourcesJarStandalone
+            version = project.version
+            pom {
+                name = "crate-jdbc-standalone"
+                description = "CrateDB JDBC Driver (Standalone)"
+                url = project.ext.url
                 licenses project.ext.licenses
                 developers project.ext.developers
-            }
-
-            repository(id: 'crate-jdbc', url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                authentication(userName: project.ext.sonatypeUsername, password: project.ext.sonatypePassword)
+                scm project.ext.scm
             }
         }
     }
+}
+
+signing {
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications)
 }
 
 test {

--- a/driver/main/resources/META-INF/LICENSE
+++ b/driver/main/resources/META-INF/LICENSE
@@ -1,0 +1,247 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===============================================================================
+
+For the `docs` directory:
+
+The source files for the documentation are licensed under the Apache License
+Version 2.0. These source files are used by the project maintainers to build
+online documentation for end-users:
+
+  <https://crate.io/docs/clients/jdbc/en/latest/>
+
+If you want to make contributions to the documentation, it may be necessary for
+you to build the documentation yourself by following the instructions in the
+`DEVELOP.rst` file. If you do this, a number of third-party software components
+are necessary.
+
+We do not ship the source code for these optional third-party software
+components or their dependencies, so we cannot make any guarantees about the
+licensing status of these components.
+
+However, for convenience, the documentation build system explicitly references
+the following software components (grouped by license):
+
+PSF License:
+
+ - Python 3 <https://docs.python.org/3/license.html>
+
+MIT License:
+
+ - pip <https://pypi.org/project/pip/>
+ - setuptools <https://pypi.org/project/setuptools/>
+ - sphinx-autobuild <https://pypi.org/project/sphinx-autobuild/>
+
+BSD License:
+
+ - alabaster <https://pypi.org/project/alabaster/>
+ - sphinx <https://pypi.org/project/Sphinx/>
+
+Apache License 2.0:
+
+ - crate-docs-theme <https://pypi.org/project/crate-docs-theme/>
+
+Please note that each of these components may specify its own dependencies and
+those dependencies may be licensed differently.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pg/build.gradle
+++ b/pg/build.gradle
@@ -7,19 +7,18 @@ def srcRoot = 'upstream/pgjdbc/src'
 
 configurations {
     jcp
-    processedMainCompile
+    processedMainCompile.extendsFrom(implementation)
 }
 
 dependencies {
-    compile 'com.github.dblock.waffle:waffle-jna:1.7.5'
-    compile 'net.java.dev.jna:jna:4.2.1'
-    compile 'net.java.dev.jna:jna-platform:4.2.1'
-    compile 'org.slf4j:jcl-over-slf4j:1.7.12'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.5.3'
-    compile 'org.osgi:org.osgi.enterprise:4.2.0'
-    compile 'org.osgi:org.osgi.core:4.3.1'
-    compile 'com.ongres.scram:client:1.0.0-beta.2'
-    processedMainCompile configurations.compile
+    api 'com.github.dblock.waffle:waffle-jna:1.7.5'
+    implementation 'net.java.dev.jna:jna:4.2.1'
+    implementation 'net.java.dev.jna:jna-platform:4.2.1'
+    implementation 'org.slf4j:jcl-over-slf4j:1.7.12'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.5.3'
+    implementation 'org.osgi:org.osgi.enterprise:4.2.0'
+    implementation 'org.osgi:org.osgi.core:4.3.1'
+    implementation 'com.ongres.scram:client:1.0.0-beta.2'
     jcp('com.igormaznitsa:jcp:6.0.1') {
         exclude group: 'org.apache.maven.*'
         exclude group: 'org.codehaus.*'
@@ -83,15 +82,7 @@ sourceSets {
     }
 }
 
-compileJava {
-    dependsOn preprocessJava
-    source = sourceSets.processedMain.java
-    options.warnings = false
-    options.deprecation = false
-    options.compilerArgs << '-XDignore.symbol.file'
-    options.fork = true
-    options.forkOptions.executable = 'javac'
-}
+compileJava.dependsOn preprocessJava
 
 test {
     enabled = false;


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

In order to use in-memory keys for signing the artifacts a
newer gradle version was required. This required some additional
changes:

 - Upgrade gradle to 8.1.1
 - Use maven-publisher plugin as the old maven plugin is gone
 - Use `gradle-nexus/publish-plugin` for publishing the artifacts
   to sonatype (includes a task to publish uploaded artifacts
   without the need of using the Nexus UI)
 - Downgrade `crate-java-testing` to 0.9.1 as newer releases
   require JDK >= 11.

Uploading and publishing the artifacts is now done via

 `publishToSonatype closeAndReleaseSonatypeStagingRepository`

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
