### PR TITLE
Fix cratedb-examples link for apache-kafka-flink application

### DIFF
--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.0"
+  "message": "2.1.2"
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,7 +161,7 @@ The project is licensed under the terms of the Apache 2.0 license, like
 
 
 .. _Apache Flink JDBC Connector: https://github.com/apache/flink-connector-jdbc
-.. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
+.. _Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/application/apache-kafka-flink
 .. _Basic example for connecting to CrateDB and CrateDB Cloud using JDBC: https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc
 .. _Build a data ingestion pipeline using Kafka, Flink, and CrateDB: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
 .. _CrateDB: https://crate.io/products/cratedb/


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Makes the link lead somewhere valid again.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
