### PR TITLE
Documentation: Fix Read The Docs configuration settings [2.7]

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,15 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,3 +5,8 @@ exclude_patterns = ['.crate-docs/**', 'requirements.txt']
 linkcheck_anchors_ignore = [
     r"diff-.*",
 ]
+
+# Enable version chooser.
+html_context.update({
+    "display_version": True,
+})

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme>=0.35.0


### PR DESCRIPTION
## About
Fix RTD configuration because build failed like [25880584](https://readthedocs.org/projects/crate-jdbc/builds/25880584/):

> Config validation error in `build.os`. Value `build` not found.

## Preview
- https://crate-jdbc--424.org.readthedocs.build/en/424/

## References
- dc71a450a22

## Remarks
This patch also needs to be applied to other branches that are configured as active versions on RTD, in total: [1.14, 2.5, 2.6, 2.7, and master](https://readthedocs.org/projects/crate-jdbc/versions/). Otherwise, [builds on them will fail](https://readthedocs.org/projects/crate-jdbc/builds/).

