### PR TITLE
Documentation: Fix Read The Docs configuration settings [2.5]

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/_extra/robots.txt
+++ b/docs/_extra/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /
+
+Sitemap: https://cratedb.com/docs/jdbc/en/latest/site.xml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,12 @@
 from crate.theme.rtd.conf.jdbc import *
 
-exclude_patterns = ['eggs/**', 'requirements.txt']
-site_url = 'https://crate.io/docs/jdbc/en/latest/'
-extensions = ['sphinx_sitemap']
+exclude_patterns = ['.crate-docs/**', 'requirements.txt']
+
+linkcheck_anchors_ignore = [
+    r"diff-.*",
+]
+
+# Enable version chooser.
+html_context.update({
+    "display_version": True,
+})

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme>=0.35.0


### PR DESCRIPTION
## About
Fix RTD configuration.

## Preview
- https://crate-jdbc--426.org.readthedocs.build/en/426/

## References
- https://github.com/crate/crate-jdbc/pull/424
