### PR TITLE
Documentation: Update Read The Docs configuration settings [master]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,3 +5,8 @@ exclude_patterns = ['.crate-docs/**', 'requirements.txt']
 linkcheck_anchors_ignore = [
     r"diff-.*",
 ]
+
+# Enable version chooser.
+html_context.update({
+    "display_version": True,
+})

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme>=0.35.0


### PR DESCRIPTION
## About
Update RTD configuration.

## Preview
- https://crate-jdbc--428.org.readthedocs.build/en/428/

## Details
- Enable version chooser.
- Use most recent version of crate-docs-theme.
