### PR TITLE
How to test on MacOS

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -79,6 +79,10 @@ or::
 
     $ CRATE_URL=https://cdn.crate.io/downloads/releases/nightly/crate-0.58.0-201611210301-7d469f8.tar.gz ./gradlew test
 
+If you are using MacOS, you have to specify the URL to download the server, e.g.::
+
+    $ CRATE_URL=https://cdn2.crate.io/downloads/releases/cratedb/x64_mac/crate-5.9.0.tar.gz ./gradlew test
+
 For debugging purposes, integration tests can be run against any CrateDB build.
 Build tar.gz file by running ./gradlew distTar from crate repository and set
 path to the generated file to the ``CRATE_PATH`` environment variable, e.g.::


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

`crate-java-testing` defaults to x86_64 Linux, and it is not possible to execute a Linux binary on a Mac. Documenting how to test on MacOS by setting `CRATE_URL`.


## Checklist

 - ~[ ] Link to issue this PR refers to (if applicable): Fixes #???~
