### PR TITLE
Documentation: Remove the flagging as "legacy driver"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==========================
-CrateDB legacy JDBC driver
-==========================
+===================
+CrateDB JDBC driver
+===================
 
 |tests| |docs| |rtd| |maven-central|
 
@@ -27,7 +27,7 @@ the JAR from source, please follow up reading the `developer guide`_.
 Documentation and help
 ======================
 
-- `CrateDB legacy JDBC driver documentation`_
+- `CrateDB JDBC driver documentation`_
 - `CrateDB reference documentation`_
 - `JDBC tutorial`_
 - `JDBC API documentation`_
@@ -47,7 +47,7 @@ GitHub`_. We appreciate contributions of any kind.
 .. _crate-jdbc-standalone: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
 .. _Crate.io: http://crate.io/
 .. _CrateDB: https://github.com/crate/crate
-.. _CrateDB legacy JDBC driver documentation: https://crate.io/docs/projects/crate-jdbc/
+.. _CrateDB JDBC driver documentation: https://crate.io/docs/projects/crate-jdbc/
 .. _CrateDB reference documentation: https://crate.io/docs/reference/
 .. _developer guide: DEVELOP.rst
 .. _installation documentation: https://crate.io/docs/jdbc/en/latest/getting-started.html

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -2,7 +2,7 @@
 Installation
 ============
 
-Learn how to install and get started with the :ref:`CrateDB legacy JDBC driver
+Learn how to install and get started with the :ref:`CrateDB JDBC driver
 <index>`.
 
 .. rubric:: Table of contents

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 .. _index:
 
-##########################
-CrateDB legacy JDBC driver
-##########################
+###################
+CrateDB JDBC Driver
+###################
 
 .. rubric:: Table of contents
 
@@ -143,7 +143,7 @@ Resources
 
 Contributions
 =============
-The CrateDB legacy JDBC driver library is an open source project, and is
+The CrateDB JDBC driver library is an open source project, and is
 managed on GitHub. Every kind of contribution, feedback, or patch, is much
 welcome. `Create an issue`_ or submit a patch if you think we should include a
 new feature, or to report or fix a bug.


### PR DESCRIPTION
## About

Various explorations certainly show that the CrateDB JDBC Driver, while a bit outdated, is preferred for compatibility and interoperability reasons. While this can change in the future any time, for example by improving CrateDB, this patch aims for better reflecting the current status quo.

/cc @hlcianfagna, @zolbatar, @simonprickett, @kneth