### PR TITLE
CI: Use all available Java LTS versions 11, 17, 21

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        java-version: ['11']
+        java-version: [
+          '11',
+          '17',
+          '21',
+          '25',
+        ]
         cratedb-version: [
           '5.10.3',
         ]


### PR DESCRIPTION
Just a little maintenance update.