### PR TITLE
Fix sonatype central JAR publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,12 @@ dependencies {
 
 nexusPublishing {
     repositories {
-        sonatype()
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username = project.hasProperty('sonatypeTokenUsername') ? sonatypeTokenUsername : ""
+            password = project.hasProperty('sonatypeTokenPassword') ? sonatypeTokenPassword : ""
+        }
     }
 }
 


### PR DESCRIPTION
The OSSRH has reached EOL, new urls must be used to publish the the Maven Central Portal instead.
See https://central.sonatype.org/pages/ossrh-eol/

Changes were verified by publishing the jmx-exporter, see https://github.com/crate/jmx_exporter/pull/84.