### PR TITLE
Revert "Bump org.mockito:mockito-core from 5.11.0 to 5.20.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.3') {
         exclude group: 'junit', module: 'junit'
     }
-    testImplementation ("org.mockito:mockito-core:5.20.0") {
+    testImplementation ("org.mockito:mockito-core:5.11.0") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
 }


### PR DESCRIPTION
## About
This reverts commit e32f6f4b430183b29dfe2c75d2fecdcc1e32b409 to probe if https://github.com/crate/crate-jdbc/pull/465 made the Jenkins job `jdbc-nightly` fail.

## References
- https://github.com/crate/crate-alerts/issues/864#issuecomment-4016266656