### PR TITLE
CI: Update integration tests to use CrateDB 5.10.16 and 6.2.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         os: ['ubuntu-latest']
         java-version: ['11']
         cratedb-version: [
-          '5.10.3',
+          '5.10.16',
         ]
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         java-version: ['11']
         cratedb-version: [
           '5.10.16',
+          '6.2.2',
         ]
 
     env:

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/BaseIntegrationTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/BaseIntegrationTest.java
@@ -39,7 +39,7 @@ public abstract class BaseIntegrationTest extends RandomizedTest {
 
     private static final String[] CRATE_VERSIONS = new String[] {
             "4.8.4",
-            "5.10.3",
+            "5.10.16",
     };
 
     @Rule

--- a/driver/test/java/io/crate/client/jdbc/integrationtests/BaseIntegrationTest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/BaseIntegrationTest.java
@@ -40,6 +40,7 @@ public abstract class BaseIntegrationTest extends RandomizedTest {
     private static final String[] CRATE_VERSIONS = new String[] {
             "4.8.4",
             "5.10.16",
+            "6.2.2",
     };
 
     @Rule


### PR DESCRIPTION
Let CI validate contemporary versions of CrateDB.