### PR TITLE
CI: Remove testing against CrateDB 4.8, it fails to start on GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
         os: ['ubuntu-latest']
         java-version: ['11']
         cratedb-version: [
-          '4.8.4',
           '5.10.3',
         ]
 


### PR DESCRIPTION
## About
Heal the build pipeline because CrateDB 4.8 stopped building on GHA.

## Details
This error makes the whole CrateDB nightly build pipeline go south, effectively stopping publishing of nightly OCI images.

```java
fatal error in thread [main], exiting java.lang.ExceptionInInitializerError: null
```
```java
NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
```
