### PR TITLE
Revert "Bump com.fasterxml.jackson.core:jackson-databind from 2.18.3 to 2.20.0

### DIFF
--- a/pg/build.gradle
+++ b/pg/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'net.java.dev.jna:jna:4.2.1'
     implementation 'net.java.dev.jna:jna-platform:4.2.1'
     implementation 'org.slf4j:jcl-over-slf4j:2.0.17'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
     implementation 'org.osgi:org.osgi.enterprise:5.0.0'
     implementation 'org.osgi:org.osgi.core:4.3.1'
     implementation 'com.ongres.scram:client:2.1'


### PR DESCRIPTION
## About
This reverts commit c62ba66902c62d6ed41829d3a3baac96385a7c91 to probe if https://github.com/crate/crate-jdbc/pull/466 made the Jenkins job `jdbc-nightly` fail.

## References
- https://github.com/crate/crate-alerts/issues/864#issuecomment-4016266656