### PR TITLE
Tests: Adjust `testException` for compatibility with CrateDB 6.2.2

### DIFF
--- a/driver/test/java/io/crate/client/jdbc/integrationtests/ConnectionITest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/ConnectionITest.java
@@ -139,7 +139,10 @@ public class ConnectionITest extends BaseIntegrationTest {
             expectedException.expect(anyOf(instanceOf(SQLException.class), instanceOf(PSQLException.class)));
             expectedException.expectMessage(anyOf(
                     containsString("line 1:1: no viable alternative at input 'ERROR'"),
-                    containsString("line 1:1: mismatched input 'ERROR' expecting {'SELECT', '"))
+                    containsString("line 1:1: mismatched input 'ERROR' expecting {'SELECT', '"),
+                    // CrateDB 6.2.2: https://github.com/crate/crate/pull/19095
+                    containsString("line 1:1: extraneous input 'ERROR' expecting {'SELECT', '")
+                    )
             );
             conn.createStatement().execute("ERROR");
         }


### PR DESCRIPTION
## About
~CrateDB 6.2.2 will accept empty statements that only include comments. Removing a test case that validates the opposite will heal the CrateDB nightly release pipeline which started failing four days ago.~

CrateDB 6.2.2 changed an error message on recent improvements.

## References
- GH-481
- https://github.com/crate/crate-alerts/issues/864#issuecomment-4016317883
- GH-476
- https://github.com/crate/crate/issues/16501
- https://github.com/crate/crate/pull/19095