### PR TITLE
CI: Run Dependabot each day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Getting notified of breaking changes earlier is beneficial so we can also react early in joining the upstream -> downstream games.