### PR TITLE
Tests: Adjust `testException` for compatibility with CrateDB 6.3.0

### DIFF
--- a/driver/test/java/io/crate/client/jdbc/integrationtests/ConnectionITest.java
+++ b/driver/test/java/io/crate/client/jdbc/integrationtests/ConnectionITest.java
@@ -140,8 +140,8 @@ public class ConnectionITest extends BaseIntegrationTest {
             expectedException.expectMessage(anyOf(
                     containsString("line 1:1: no viable alternative at input 'ERROR'"),
                     containsString("line 1:1: mismatched input 'ERROR' expecting {'SELECT', '"),
-                    // CrateDB 6.2.2: https://github.com/crate/crate/pull/19095
-                    containsString("line 1:1: extraneous input 'ERROR' expecting {'SELECT', '")
+                    // CrateDB 6.3.0: https://github.com/crate/crate-jdbc/issues/481
+                    containsString("line 1:1: extraneous input 'ERROR' expecting {")
                     )
             );
             conn.createStatement().execute("ERROR");


### PR DESCRIPTION
## About
CrateDB 6.3.0 starts ignoring empty statements, which made the nightly build pipeline fail starting four days ago.

## References
- GH-481
- https://github.com/crate/crate-alerts/issues/864#issuecomment-4016317883
- GH-476
- https://github.com/crate/crate/issues/16501
- https://github.com/crate/crate/pull/19095
